### PR TITLE
 Reformatted some of the easy PEP8 failures

### DIFF
--- a/src/toil/batchSystems/__init__.py
+++ b/src/toil/batchSystems/__init__.py
@@ -19,14 +19,14 @@ from builtins import object
 import sys
 
 if sys.version_info >= (3, 0):
-
     # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
     def cmp(a, b):
         return (a > b) - (a < b)
 
+
 class MemoryString(object):
     def __init__(self, string):
-        if string[-1] == 'K' or string[-1] == 'M' or string[-1] == 'G' or string[-1] == 'T': #10K
+        if string[-1] == 'K' or string[-1] == 'M' or string[-1] == 'G' or string[-1] == 'T':  # 10K
             self.unit = string[-1]
             self.val = float(string[:-1])
         elif len(string) >= 3 and (string[-2] == 'k' or string[-2] == 'M' or string[-2] == 'G' or string[-2] == 'T'):

--- a/src/toil/batchSystems/abstractBatchSystem.py
+++ b/src/toil/batchSystems/abstractBatchSystem.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import object
 import os
@@ -35,7 +36,6 @@ from future.utils import with_metaclass
 
 logger = logging.getLogger(__name__)
 
-
 # A class containing the information required for worker cleanup on shutdown of the batch system.
 WorkerCleanupInfo = namedtuple('WorkerCleanupInfo', (
     # A path to the value of config.workDir (where the cache would go)
@@ -44,6 +44,7 @@ WorkerCleanupInfo = namedtuple('WorkerCleanupInfo', (
     'workflowID',
     # The value of the cleanWorkDir flag
     'cleanWorkDir'))
+
 
 class AbstractBatchSystem(with_metaclass(ABCMeta, object)):
     """
@@ -184,7 +185,6 @@ class AbstractBatchSystem(with_metaclass(ABCMeta, object)):
         """
         raise NotImplementedError()
 
-
     @classmethod
     def setOptions(cls, setOption):
         """
@@ -195,8 +195,8 @@ class AbstractBatchSystem(with_metaclass(ABCMeta, object)):
            used to update run configuration
         """
         pass
-        
-    
+
+
 class BatchSystemSupport(AbstractBatchSystem):
     """
     Partial implementation of AbstractBatchSystem, support methods.
@@ -254,7 +254,6 @@ class BatchSystemSupport(AbstractBatchSystem):
             raise InsufficientSystemResources('memory', memory, self.maxMemory)
         if disk > self.maxDisk:
             raise InsufficientSystemResources('disk', disk, self.maxDisk)
-
 
     def setEnv(self, name, value=None):
         """
@@ -324,6 +323,7 @@ class BatchSystemSupport(AbstractBatchSystem):
             and workflowDirContents in ([], [cacheDirName(info.workflowID)])):
             shutil.rmtree(workflowDir)
 
+
 class NodeInfo(object):
     """
     The coresUsed attribute  is a floating point value between 0 (all cores idle) and 1 (all cores
@@ -340,6 +340,7 @@ class NodeInfo(object):
     The workers attribute is an integer reflecting the number of workers currently active workers
     on the node.
     """
+
     def __init__(self, coresUsed, memoryUsed, coresTotal, memoryTotal,
                  requestedCores, requestedMemory, workers):
         self.coresUsed = coresUsed
@@ -428,11 +429,13 @@ class AbstractScalableBatchSystem(AbstractBatchSystem):
         """
         raise NotImplementedError()
 
+
 class InsufficientSystemResources(Exception):
     """
     To be raised when a job requests more of a particular resource than is either currently allowed
     or avaliable
     """
+
     def __init__(self, resource, requested, available):
         """
         Creates an instance of this exception that indicates which resource is insufficient for current

--- a/src/toil/batchSystems/abstractGridEngineBatchSystem.py
+++ b/src/toil/batchSystems/abstractGridEngineBatchSystem.py
@@ -31,6 +31,7 @@ from bd2k.util.objects import abstractclassmethod
 
 from toil.batchSystems.abstractBatchSystem import BatchSystemSupport
 from toil.batchSystems import registry
+
 try:
     from toil.cwl.cwltoil import CWL_INTERNAL_JOBS
 except ImportError:
@@ -38,6 +39,7 @@ except ImportError:
     CWL_INTERNAL_JOBS = ()
 
 logger = logging.getLogger(__name__)
+
 
 class AbstractGridEngineBatchSystem(BatchSystemSupport):
     """
@@ -190,7 +192,8 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
             time period to talk with the scheduler.
             """
             if (self._checkOnJobsTimestamp and
-                 (datetime.now() - self._checkOnJobsTimestamp).total_seconds() < self.boss.config.statePollingWait):
+                        (
+                                    datetime.now() - self._checkOnJobsTimestamp).total_seconds() < self.boss.config.statePollingWait):
                 return self._checkOnJobsCache
 
             activity = False
@@ -283,7 +286,6 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
             """
             raise NotImplementedError()
 
-
     def __init__(self, config, maxCores, maxMemory, maxDisk):
         super(AbstractGridEngineBatchSystem, self).__init__(config, maxCores, maxMemory, maxDisk)
 
@@ -305,7 +307,7 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
         self.killedJobsQueue = Queue()
         # get the associated worker class here
         self.worker = self.Worker(self.newJobsQueue, self.updatedJobsQueue, self.killQueue,
-                              self.killedJobsQueue, self)
+                                  self.killedJobsQueue, self)
         self.worker.start()
         self.localBatch = registry.batchSystemFactoryFor(registry.defaultBatchSystem())()(config, maxCores,
                                                                                           maxMemory, maxDisk)
@@ -373,7 +375,8 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
         """
         localIds = self.localBatch.getRunningBatchJobIDs()
         if (self._getRunningBatchJobIDsTimestamp and
-             (datetime.now() - self._getRunningBatchJobIDsTimestamp).total_seconds() < self.config.statePollingWait):
+                    (
+                                datetime.now() - self._getRunningBatchJobIDsTimestamp).total_seconds() < self.config.statePollingWait):
             batchIds = self._getRunningBatchJobIDsCache
         else:
             batchIds = self.worker.getRunningJobIDs()
@@ -410,7 +413,7 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
     def setEnv(self, name, value=None):
         if value and ',' in value:
             raise ValueError(type(self).__name__ + " does not support commata in environment variable values")
-        return super(AbstractGridEngineBatchSystem,self).setEnv(name, value)
+        return super(AbstractGridEngineBatchSystem, self).setEnv(name, value)
 
     @classmethod
     def getWaitDuration(self):
@@ -418,7 +421,7 @@ class AbstractGridEngineBatchSystem(BatchSystemSupport):
 
     @classmethod
     def getRescueBatchJobFrequency(cls):
-        return 30 * 60 # Half an hour
+        return 30 * 60  # Half an hour
 
     def sleepSeconds(self, sleeptime=1):
         """ Helper function to drop on all state-querying functions to avoid over-querying.

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -34,13 +34,14 @@ from toil.batchSystems.abstractGridEngineBatchSystem import AbstractGridEngineBa
 
 logger = logging.getLogger(__name__)
 
-class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
 
+class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
     class Worker(AbstractGridEngineBatchSystem.Worker):
 
         """
         Grid Engine-specific AbstractGridEngineWorker methods
         """
+
         def getRunningJobIDs(self):
             times = {}
             currentjobs = dict((str(self.batchJobIDs[x][0]), x) for x in self.runningJobs)
@@ -92,6 +93,7 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
         """
         Implementation-specific helper methods
         """
+
         def prepareQsub(self, cpu, mem, jobID):
             qsubline = ['qsub', '-V', '-b', 'y', '-terse', '-j', 'y', '-cwd',
                         '-N', 'toil_job_' + str(jobID)]
@@ -112,7 +114,8 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
                 sgeArgs = sgeArgs.split()
                 for arg in sgeArgs:
                     if arg.startswith(("vf=", "hvmem=", "-pe")):
-                        raise ValueError("Unexpected CPU, memory or pe specifications in TOIL_GRIDGENGINE_ARGs: %s" % arg)
+                        raise ValueError(
+                            "Unexpected CPU, memory or pe specifications in TOIL_GRIDGENGINE_ARGs: %s" % arg)
                 qsubline.extend(sgeArgs)
             if cpu is not None and math.ceil(cpu) > 1:
                 peConfig = os.getenv('TOIL_GRIDENGINE_PE') or 'shm'
@@ -131,6 +134,7 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
     def obtainSystemConstants(cls):
         def byteStrip(s):
             return s.encode().strip()
+
         lines = [_f for _f in map(byteStrip, subprocess.check_output(["qhost"]).split('\n')) if _f]
         line = lines[0]
         items = line.strip().split()

--- a/src/toil/batchSystems/lsfHelper.py
+++ b/src/toil/batchSystems/lsfHelper.py
@@ -36,6 +36,7 @@ LSF_CONF_ENV = ["LSF_CONFDIR", "LSF_ENVDIR"]
 DEFAULT_LSF_UNITS = "KB"
 DEFAULT_RESOURCE_UNITS = "MB"
 
+
 def find(basedir, string):
     """
     walk basedir and return all files matching string
@@ -46,6 +47,7 @@ def find(basedir, string):
             matches.append(os.path.join(root, filename))
     return matches
 
+
 def find_first_match(basedir, string):
     """
     return the first file that matches string starting from basedir
@@ -53,12 +55,14 @@ def find_first_match(basedir, string):
     matches = find(basedir, string)
     return matches[0] if matches else matches
 
+
 def get_conf_file(filename, env):
     conf_path = os.environ.get(env)
     if not conf_path:
         return None
     conf_file = find_first_match(conf_path, filename)
     return conf_file
+
 
 def apply_conf_file(fn, conf_filename):
     for env in LSF_CONF_ENV:
@@ -70,17 +74,20 @@ def apply_conf_file(fn, conf_filename):
                 return value
     return None
 
+
 def per_core_reserve_from_stream(stream):
     for k, v in tokenize_conf_stream(stream):
         if k == "RESOURCE_RESERVE_PER_SLOT":
             return v.upper()
     return None
 
+
 def get_lsf_units_from_stream(stream):
     for k, v in tokenize_conf_stream(stream):
         if k == "LSF_UNIT_FOR_LIMITS":
             return v
     return None
+
 
 def tokenize_conf_stream(conf_handle):
     """
@@ -94,6 +101,7 @@ def tokenize_conf_stream(conf_handle):
             continue
         yield (tokens[0].strip(), tokens[1].strip())
 
+
 def apply_bparams(fn):
     """
     apply fn to each line of bparams, returning the result
@@ -104,6 +112,7 @@ def apply_bparams(fn):
     except:
         return None
     return fn(output.split("\n"))
+
 
 def apply_lsadmin(fn):
     """
@@ -140,6 +149,7 @@ def get_lsf_units(resource=False):
     else:
         return DEFAULT_LSF_UNITS
 
+
 def parse_memory(mem):
     """
     Parse memory parameter
@@ -174,6 +184,7 @@ def per_core_reservation():
         return False
     return False
 
+
 def convert_mb(kb, unit):
     UNITS = {"B": -2,
              "KB": -1,
@@ -185,7 +196,6 @@ def convert_mb(kb, unit):
     return int(old_div(float(kb), float(math.pow(1024, UNITS[unit]))))
 
 
-
 if __name__ == "__main__":
-    print (get_lsf_units())
-    print (per_core_reservation())
+    print(get_lsf_units())
+    print(per_core_reservation())

--- a/src/toil/batchSystems/mesos/__init__.py
+++ b/src/toil/batchSystems/mesos/__init__.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import object
 from queue import Queue
@@ -38,7 +39,6 @@ TaskData = namedtuple('TaskData', (
 
 
 class JobQueue(object):
-
     def __init__(self):
         # mapping of jobTypes to queues of jobs of that type
         self.queues = {}
@@ -94,7 +94,6 @@ class ResourceRequirement(object):
         """
         return self.cores
 
-
     def __gt__(self, other):
         """
         Returns True if self is greater than other, else returns False.
@@ -136,9 +135,9 @@ class ResourceRequirement(object):
 
     def __eq__(self, other):
         if (self.preemptable == other.preemptable and
-           self.cores == other.cores and
-           self.memory == other.memory and
-           self.disk == other.disk):
+                    self.cores == other.cores and
+                    self.memory == other.memory and
+                    self.disk == other.disk):
             return True
         return False
 

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -400,7 +400,7 @@ class MesosBatchSystem(BatchSystemSupport,
         for offer in offers:
             if offer.hostname in self.ignoredNodes:
                 log.debug("Declining offer %s because node %s is designated for termination" %
-                        (offer.id.value, offer.hostname))
+                          (offer.id.value, offer.hostname))
                 driver.declineOffer(offer.id)
                 continue
             runnableTasks = []
@@ -420,7 +420,7 @@ class MesosBatchSystem(BatchSystemSupport,
                 # loop.
                 nextToLaunchIndex = 0
                 # Toil specifies disk and memory in bytes but Mesos uses MiB
-                while ( not self.jobQueues.typeEmpty(jobType)
+                while (not self.jobQueues.typeEmpty(jobType)
                        # On a non-preemptable node we can run any job, on a preemptable node we
                        # can only run preemptable jobs:
                        and (not offerPreemptable or jobType.preemptable)
@@ -462,9 +462,9 @@ class MesosBatchSystem(BatchSystemSupport,
         if unableToRun and time.time() > (self.lastTimeOfferLogged + self.logPeriod):
             self.lastTimeOfferLogged = time.time()
             log.debug('Although there are queued jobs, none of them were able to run in '
-                     'any of the offers extended to the framework. There are currently '
-                     '%i jobs running. Enable debug level logging to see more details about '
-                     'job types and offers received.', len(self.runningJobMap))
+                      'any of the offers extended to the framework. There are currently '
+                      '%i jobs running. Enable debug level logging to see more details about '
+                      'job types and offers received.', len(self.runningJobMap))
 
     def _trackOfferedNodes(self, offers):
         for offer in offers:
@@ -635,11 +635,10 @@ class MesosBatchSystem(BatchSystemSupport,
         """
         log.warning("Executor '%s' lost.", executorId)
 
-
     @classmethod
     def setOptions(cl, setOption):
         setOption("mesosMasterAddress", None, None, 'localhost:5050')
-        
+
 
 def toMiB(n):
     return n / 1024 / 1024

--- a/src/toil/batchSystems/mesos/executor.py
+++ b/src/toil/batchSystems/mesos/executor.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import str
 import os

--- a/src/toil/batchSystems/options.py
+++ b/src/toil/batchSystems/options.py
@@ -18,6 +18,7 @@ from .registry import batchSystemFactoryFor, defaultBatchSystem, uniqueNames
 import socket
 from contextlib import closing
 
+
 def getPublicIP():
     """Get the IP that this machine uses to contact the internet.
 
@@ -38,10 +39,11 @@ def getPublicIP():
         # to provide a default argument
         return '127.0.0.1'
 
+
 def _parasolOptions(addOptionFn):
     addOptionFn("--parasolCommand", dest="parasolCommand", default=None,
-                      help="The name or path of the parasol program. Will be looked up on PATH "
-                           "unless it starts with a slashdefault=%s" % 'parasol')
+                help="The name or path of the parasol program. Will be looked up on PATH "
+                     "unless it starts with a slashdefault=%s" % 'parasol')
     addOptionFn("--parasolMaxBatches", dest="parasolMaxBatches", default=None,
                 help="Maximum number of job batches the Parasol batch is allowed to create. One "
                      "batch is created for jobs with a a unique set of resource requirements. "
@@ -62,12 +64,13 @@ def _mesosOptions(addOptionFn):
     addOptionFn("--mesosMaster", dest="mesosMasterAddress", default=getPublicIP() + ':5050',
                 help=("The host and port of the Mesos master separated by colon. (default: %(default)s)"))
 
+
 # Built in batch systems that have options
 _OPTIONS = [
     _parasolOptions,
     _singleMachineOptions,
     _mesosOptions
-    ]
+]
 
 _options = list(_OPTIONS)
 
@@ -97,6 +100,7 @@ def addOptions(addOptionFn):
     for o in _options:
         o(addOptionFn)
 
+
 def setDefaultOptions(config):
     """
     Set default options for builtin batch systems. This is required if a Config
@@ -105,7 +109,7 @@ def setDefaultOptions(config):
     config.batchSystem = "singleMachine"
     config.disableHotDeployment = False
     config.environment = {}
-    config.statePollingWait = 1 # seconds
+    config.statePollingWait = 1  # seconds
 
     # single machine
     config.scale = 1

--- a/src/toil/batchSystems/parasol.py
+++ b/src/toil/batchSystems/parasol.py
@@ -145,7 +145,7 @@ class ParasolBatchSystem(BatchSystemSupport):
         # meams the new job can't ever decrease the memory requirements
         # of jobs already in the batch.
         if len(self.resultsFiles) >= self.maxBatches:
-            raise RuntimeError( 'Number of batches reached limit of %i' % self.maxBatches)
+            raise RuntimeError('Number of batches reached limit of %i' % self.maxBatches)
         try:
             results = self.resultsFiles[(truncatedMemory, jobNode.cores)]
         except KeyError:
@@ -213,8 +213,8 @@ class ParasolBatchSystem(BatchSystemSupport):
             runningJobs = self.getIssuedBatchJobIDs()
             if set(jobIDs).difference(set(runningJobs)) == set(jobIDs):
                 break
-            logger.warn( 'Tried to kill some jobs, but something happened and they are still '
-                         'going, will try againin 5s.')
+            logger.warn('Tried to kill some jobs, but something happened and they are still '
+                        'going, will try againin 5s.')
             time.sleep(5)
         # Update the CPU usage, because killed jobs aren't written to the results file.
         for jobID in jobIDs:
@@ -346,7 +346,7 @@ class ParasolBatchSystem(BatchSystemSupport):
                             # second.
                             usrTicks = int(usrTicks)
                             sysTicks = int(sysTicks)
-                            wallTime = float( max( 1, usrTicks + sysTicks) ) * 0.01
+                            wallTime = float(max(1, usrTicks + sysTicks)) * 0.01
                         else:
                             wallTime = float(endTime - startTime)
                         self.updatedJobsQueue.put((jobId, status, wallTime))
@@ -377,10 +377,8 @@ class ParasolBatchSystem(BatchSystemSupport):
             os.remove(results)
         os.rmdir(self.parasolResultsDir)
 
-
     @classmethod
     def setOptions(cls, setOption):
         from toil.common import iC
         setOption("parasolCommand", None, None, 'parasol')
         setOption("parasolMaxBatches", int, iC(1), 10000)
-        

--- a/src/toil/batchSystems/registry.py
+++ b/src/toil/batchSystems/registry.py
@@ -16,25 +16,31 @@ def _gridengineBatchSystemFactory():
     from toil.batchSystems.gridengine import GridEngineBatchSystem
     return GridEngineBatchSystem
 
+
 def _parasolBatchSystemFactory():
     from toil.batchSystems.parasol import ParasolBatchSystem
     return ParasolBatchSystem
+
 
 def _lsfBatchSystemFactory():
     from toil.batchSystems.lsf import LSFBatchSystem
     return LSFBatchSystem
 
+
 def _singleMachineBatchSystemFactory():
     from toil.batchSystems.singleMachine import SingleMachineBatchSystem
     return SingleMachineBatchSystem
+
 
 def _mesosBatchSystemFactory():
     from toil.batchSystems.mesos.batchSystem import MesosBatchSystem
     return MesosBatchSystem
 
+
 def _slurmBatchSystemFactory():
     from toil.batchSystems.slurm import SlurmBatchSystem
     return SlurmBatchSystem
+
 
 def _torqueBatchSystemFactory():
     from toil.batchSystems.torque import TorqueBatchSystem
@@ -42,20 +48,20 @@ def _torqueBatchSystemFactory():
 
 
 _DEFAULT_REGISTRY = {
-    'parasol'        : _parasolBatchSystemFactory,
-    'singleMachine'  : _singleMachineBatchSystemFactory,
-    'single_machine' : _singleMachineBatchSystemFactory,
-    'gridEngine'     : _gridengineBatchSystemFactory,
-    'gridengine'     : _gridengineBatchSystemFactory,
-    'lsf'            : _lsfBatchSystemFactory,
-    'LSF'            : _lsfBatchSystemFactory,
-    'mesos'          : _mesosBatchSystemFactory,
-    'Mesos'          : _mesosBatchSystemFactory,
-    'slurm'          : _slurmBatchSystemFactory,
-    'Slurm'          : _slurmBatchSystemFactory,
-    'torque'         : _torqueBatchSystemFactory,
-    'Torque'         : _torqueBatchSystemFactory
-    }
+    'parasol': _parasolBatchSystemFactory,
+    'singleMachine': _singleMachineBatchSystemFactory,
+    'single_machine': _singleMachineBatchSystemFactory,
+    'gridEngine': _gridengineBatchSystemFactory,
+    'gridengine': _gridengineBatchSystemFactory,
+    'lsf': _lsfBatchSystemFactory,
+    'LSF': _lsfBatchSystemFactory,
+    'mesos': _mesosBatchSystemFactory,
+    'Mesos': _mesosBatchSystemFactory,
+    'slurm': _slurmBatchSystemFactory,
+    'Slurm': _slurmBatchSystemFactory,
+    'torque': _torqueBatchSystemFactory,
+    'Torque': _torqueBatchSystemFactory
+}
 
 _UNIQUE_NAME = {
     'parasol',
@@ -65,23 +71,28 @@ _UNIQUE_NAME = {
     'Mesos',
     'Slurm',
     'Torque'
-        }
+}
 
 _batchSystemRegistry = _DEFAULT_REGISTRY.copy()
 _batchSystemNames = set(_UNIQUE_NAME)
+
 
 def addBatchSystemFactory(key, batchSystemFactory):
     _batchSystemNames.add(key)
     _batchSystemRegistry[key] = batchSystemFactory
 
+
 def batchSystemFactoryFor(batchSystem):
-    return _batchSystemRegistry[batchSystem ]
+    return _batchSystemRegistry[batchSystem]
+
 
 def defaultBatchSystem():
     return 'singleMachine'
 
+
 def uniqueNames():
     return list(_batchSystemNames)
+
 
 def batchSystems():
     list(set(_batchSystemRegistry.values()))

--- a/src/toil/batchSystems/singleMachine.py
+++ b/src/toil/batchSystems/singleMachine.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import str
 from builtins import range
@@ -125,8 +126,8 @@ class SingleMachineBatchSystem(BatchSystemSupport):
 
         if not self.debugWorker:
             log.debug('Setting up the thread pool with %i workers, '
-                     'given a minimum CPU fraction of %f '
-                     'and a maximum CPU value of %i.', self.numWorkers, self.minCores, maxCores)
+                      'given a minimum CPU fraction of %f '
+                      'and a maximum CPU value of %i.', self.numWorkers, self.minCores, maxCores)
             for i in range(self.numWorkers):
                 worker = Thread(target=self.worker, args=(self.inputQueue,))
                 self.workerThreads.append(worker)
@@ -226,8 +227,8 @@ class SingleMachineBatchSystem(BatchSystemSupport):
                                         'set to {}.'.format(jobNode.jobName, cores, self.maxCores, self.scale))
         assert cores >= self.minCores
         assert jobNode.memory <= self.maxMemory, ('The job {} is requesting {} bytes of memory, more than '
-                                          'the maximum of {} this batch system was configured '
-                                          'with.'.format(jobNode.jobName, jobNode.memory, self.maxMemory))
+                                                  'the maximum of {} this batch system was configured '
+                                                  'with.'.format(jobNode.jobName, jobNode.memory, self.maxMemory))
 
         self.checkResourceRequest(jobNode.memory, cores, jobNode.disk)
         log.debug("Issuing the command: %s with memory: %i, cores: %i, disk: %i" % (
@@ -302,7 +303,8 @@ class SingleMachineBatchSystem(BatchSystemSupport):
     @classmethod
     def setOptions(cls, setOption):
         setOption("scale", default=1)
-        
+
+
 class Info(object):
     # Can't use namedtuple here since killIntended needs to be mutable
     def __init__(self, startTime, popen, killIntended):
@@ -380,5 +382,3 @@ class ResourcePool(object):
             self.requested = requested
             self.available = available
             self.resource = resource
-
-

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import str
 from builtins import range
@@ -46,7 +47,6 @@ from toil.batchSystems.options import addOptions as addBatchOptions
 from toil.batchSystems.options import setDefaultOptions as setDefaultBatchOptions
 from toil.batchSystems.options import setOptions as setBatchOptions
 
-
 logger = logging.getLogger(__name__)
 
 # This constant is set to the default value used on unix for block size (in bytes) when
@@ -58,6 +58,7 @@ class Config(object):
     """
     Class to represent configuration operations for a toil workflow run.
     """
+
     def __init__(self):
         # Core options
         self.workflowID = None
@@ -77,13 +78,13 @@ class Config(object):
         self.cleanWorkDir = None
         self.clusterStats = None
 
-        #Restarting the workflow options
+        # Restarting the workflow options
         self.restart = False
 
-        #Batch system options
+        # Batch system options
         setDefaultBatchOptions(self)
 
-        #Autoscaling options
+        # Autoscaling options
         self.provisioner = None
         self.nodeTypes = []
         self.nodeOptions = None
@@ -94,14 +95,14 @@ class Config(object):
         self.scaleInterval = 30
         self.preemptableCompensation = 0.0
         self.nodeStorage = 50
-        
+
         # Parameters to limit service jobs, so preventing deadlock scheduling scenarios
         self.maxPreemptableServiceJobs = sys.maxsize
         self.maxServiceJobs = sys.maxsize
-        self.deadlockWait = 60 # Wait one minute before declaring a deadlock
-        self.statePollingWait = 1 # Wait 1 seconds before querying job state
+        self.deadlockWait = 60  # Wait one minute before declaring a deadlock
+        self.statePollingWait = 1  # Wait 1 seconds before querying job state
 
-        #Resource requirements
+        # Resource requirements
         self.defaultMemory = 2147483648
         self.defaultCores = 1
         self.defaultDisk = 2147483648
@@ -111,12 +112,12 @@ class Config(object):
         self.maxMemory = sys.maxsize
         self.maxDisk = sys.maxsize
 
-        #Retrying/rescuing jobs
+        # Retrying/rescuing jobs
         self.retryCount = 0
         self.maxJobDuration = sys.maxsize
         self.rescueJobsFrequency = 3600
 
-        #Misc
+        # Misc
         self.disableCaching = False
         self.maxLogFileSize = 64000
         self.writeLogs = None
@@ -126,7 +127,7 @@ class Config(object):
         self.servicePollingInterval = 60
         self.useAsync = True
 
-        #Debug options
+        # Debug options
         self.debugWorker = False
         self.badWorker = 0.0
         self.badWorkerFailInterval = 0.01
@@ -135,11 +136,11 @@ class Config(object):
         """
         Creates a config object from the options object.
         """
-        from bd2k.util.humanize import human2bytes #This import is used to convert
-        #from human readable quantites to integers
+        from bd2k.util.humanize import human2bytes  # This import is used to convert
+        # from human readable quantites to integers
         def setOption(varName, parsingFn=None, checkFn=None, default=None):
-            #If options object has the option "varName" specified
-            #then set the "varName" attrib to this value in the config object
+            # If options object has the option "varName" specified
+            # then set the "varName" attrib to this value in the config object
             x = getattr(options, varName, None)
             if x is None:
                 x = default
@@ -156,7 +157,7 @@ class Config(object):
                 setattr(self, varName, x)
 
         # Function to parse integer from string expressed in different formats
-        h2b = lambda x : human2bytes(str(x))
+        h2b = lambda x: human2bytes(str(x))
 
         def parseJobStore(s):
             name, rest = Toil.parseLocator(s)
@@ -166,18 +167,20 @@ class Config(object):
                 return Toil.buildLocator(name, os.path.abspath(rest))
             else:
                 return s
+
         def parseStrList(s):
             s = s.split(",")
             s = [str(x) for x in s]
             return s
+
         def parseIntList(s):
             s = s.split(",")
             s = [int(x) for x in s]
             return s
 
-        #Core options
+        # Core options
         setOption("jobStore", parsingFn=parseJobStore)
-        #TODO: LOG LEVEL STRING
+        # TODO: LOG LEVEL STRING
         setOption("workDir")
         if self.workDir is not None:
             self.workDir = os.path.abspath(self.workDir)
@@ -198,10 +201,10 @@ class Config(object):
             self.clean = "onSuccess"
         setOption('clusterStats')
 
-        #Restarting the workflow options
+        # Restarting the workflow options
         setOption("restart")
 
-        #Batch system options
+        # Batch system options
         setOption("batchSystem")
         setBatchOptions(self, setOption)
         setOption("disableHotDeployment")
@@ -213,7 +216,7 @@ class Config(object):
 
         setOption("environment", parseSetEnv)
 
-        #Autoscaling options
+        # Autoscaling options
         setOption("provisioner")
         setOption("nodeTypes", parseStrList)
         setOption("nodeOptions")
@@ -244,12 +247,12 @@ class Config(object):
         setOption("maxDisk", h2b, iC(1))
         setOption("defaultPreemptable")
 
-        #Retrying/rescuing jobs
+        # Retrying/rescuing jobs
         setOption("retryCount", int, iC(0))
         setOption("maxJobDuration", int, iC(1))
         setOption("rescueJobsFrequency", int, iC(1))
 
-        #Misc
+        # Misc
         setOption("disableCaching")
         setOption("maxLogFileSize", h2b, iC(1))
         setOption("writeLogs")
@@ -257,12 +260,13 @@ class Config(object):
 
         def checkSse(sseKey):
             with open(sseKey) as f:
-                assert(len(f.readline().rstrip()) == 32)
+                assert (len(f.readline().rstrip()) == 32)
+
         setOption("sseKey", checkFn=checkSse)
         setOption("cseKey", checkFn=checkSse)
         setOption("servicePollingInterval", float, fC(0.0))
 
-        #Debug options
+        # Debug options
         setOption("debugWorker")
         setOption("badWorker", float, fC(0.0, 1.0))
         setOption("badWorkerFailInterval", float, fC(0.0))
@@ -272,6 +276,7 @@ class Config(object):
 
     def __hash__(self):
         return self.__dict__.__hash__()
+
 
 jobStoreLocatorHelp = ("A job store holds persistent information about the jobs and files in a "
                        "workflow. If the workflow is run with a distributed batch system, the job "
@@ -287,9 +292,10 @@ jobStoreLocatorHelp = ("A job store holds persistent information about the jobs 
                        "For backwards compatibility, you may also specify ./foo (equivalent to "
                        "file:./foo or just file:foo) or /bar (equivalent to file:/bar).")
 
+
 def _addOptions(addGroupFn, config):
     #
-    #Core options
+    # Core options
     #
     addOptionFn = addGroupFn("toil core options",
                              "Options to specify the location of the Toil workflow and turn on "
@@ -325,7 +331,7 @@ def _addOptions(addGroupFn, config):
                      "should be written. This options only applies when using scalable batch "
                      "systems.")
     #
-    #Restarting the workflow options
+    # Restarting the workflow options
     #
     addOptionFn = addGroupFn("toil options for restarting an existing workflow",
                              "Allows the restart of an existing workflow")
@@ -335,7 +341,7 @@ def _addOptions(addGroupFn, config):
                      "if the workflow does not exist")
 
     #
-    #Batch system options
+    # Batch system options
     #
 
     addOptionFn = addGroupFn("toil options for specifying the batch system",
@@ -344,7 +350,7 @@ def _addOptions(addGroupFn, config):
     addBatchOptions(addOptionFn)
 
     #
-    #Auto scaling options
+    # Auto scaling options
     #
     addOptionFn = addGroupFn("toil options for autoscaling the cluster of worker nodes",
                              "Allows the specification of the minimum and maximum number of nodes "
@@ -356,33 +362,33 @@ def _addOptions(addGroupFn, config):
                      "'cgcloud' or 'aws'. The default is %s." % config.provisioner)
 
     addOptionFn('--nodeTypes', default=None,
-                 help="List of node types separated by commas. The syntax for each node type "
-                      "depends on the provisioner used. For the cgcloud and AWS provisioners "
-                      "this is the name of an EC2 instance type, optionally followed by a "
-                      "colon and the price in dollars "
-                      "to bid for a spot instance of that type, for example 'c3.8xlarge:0.42'."
-                      "If no spot bid is specified, nodes of this type will be non-preemptable."
-                      "It is acceptable to specify an instance as both preemptable and "
-                      "non-preemptable, including it twice in the list. In that case,"
-                      "preemptable nodes of that type will be preferred when creating "
-                      "new nodes once the maximum number of preemptable-nodes has been"
-                      "reached.")
+                help="List of node types separated by commas. The syntax for each node type "
+                     "depends on the provisioner used. For the cgcloud and AWS provisioners "
+                     "this is the name of an EC2 instance type, optionally followed by a "
+                     "colon and the price in dollars "
+                     "to bid for a spot instance of that type, for example 'c3.8xlarge:0.42'."
+                     "If no spot bid is specified, nodes of this type will be non-preemptable."
+                     "It is acceptable to specify an instance as both preemptable and "
+                     "non-preemptable, including it twice in the list. In that case,"
+                     "preemptable nodes of that type will be preferred when creating "
+                     "new nodes once the maximum number of preemptable-nodes has been"
+                     "reached.")
 
     addOptionFn('--nodeOptions', default=None,
-                 help="Options for provisioning the nodes. The syntax "
-                      "depends on the provisioner used. Neither the CGCloud nor the AWS "
-                      "provisioner support any node options.")
+                help="Options for provisioning the nodes. The syntax "
+                     "depends on the provisioner used. Neither the CGCloud nor the AWS "
+                     "provisioner support any node options.")
 
-    addOptionFn('--minNodes', default=None, 
-                 help="Mininum number of nodes of each type in the cluster, if using "
-                              "auto-scaling. This should be provided as a comma-separated "
-                              "list of the same length as the list of node types. default=0")
+    addOptionFn('--minNodes', default=None,
+                help="Mininum number of nodes of each type in the cluster, if using "
+                     "auto-scaling. This should be provided as a comma-separated "
+                     "list of the same length as the list of node types. default=0")
 
     addOptionFn('--maxNodes', default=None,
                 help="Maximum number of nodes of each type in the cluster, if using "
-                "autoscaling, provided as a comma-separated list. The first value is used "
-                "as a default if the list length is less than the number of nodeTypes. "
-                "default=%s" % config.maxNodes[0])
+                     "autoscaling, provided as a comma-separated list. The first value is used "
+                     "as a default if the list length is less than the number of nodeTypes. "
+                     "default=%s" % config.maxNodes[0])
 
     # TODO: DESCRIBE THE FOLLOWING TWO PARAMETERS
     addOptionFn("--alphaPacking", dest="alphaPacking", default=None,
@@ -411,7 +417,7 @@ def _addOptions(addGroupFn, config):
                 help=("Specify the size of the root volume of worker nodes when they are launched "
                       "in gigabytes. You may want to set this if your jobs require a lot of disk "
                       "space. The default value is 50."))
-    
+
     #        
     # Parameters to limit service jobs / detect service deadlocks
     #
@@ -420,17 +426,20 @@ def _addOptions(addGroupFn, config):
                              "in a cluster. By keeping this limited "
                              " we can avoid all the nodes being occupied with services, so causing a deadlock")
     addOptionFn("--maxServiceJobs", dest="maxServiceJobs", default=None,
-                help=("The maximum number of service jobs that can be run concurrently, excluding service jobs running on preemptable nodes. default=%s" % config.maxServiceJobs))
+                help=(
+                    "The maximum number of service jobs that can be run concurrently, excluding service jobs running on preemptable nodes. default=%s" % config.maxServiceJobs))
     addOptionFn("--maxPreemptableServiceJobs", dest="maxPreemptableServiceJobs", default=None,
-                help=("The maximum number of service jobs that can run concurrently on preemptable nodes. default=%s" % config.maxPreemptableServiceJobs))
+                help=(
+                    "The maximum number of service jobs that can run concurrently on preemptable nodes. default=%s" % config.maxPreemptableServiceJobs))
     addOptionFn("--deadlockWait", dest="deadlockWait", default=None,
-                help=("The minimum number of seconds to observe the cluster stuck running only the same service jobs before throwing a deadlock exception. default=%s" % config.deadlockWait))
+                help=(
+                    "The minimum number of seconds to observe the cluster stuck running only the same service jobs before throwing a deadlock exception. default=%s" % config.deadlockWait))
     addOptionFn("--statePollingWait", dest="statePollingWait", default=1,
                 help=("Time, in seconds, to wait before doing a scheduler query for job state. "
                       "Return cached results if within the waiting period."))
 
     #
-    #Resource requirements
+    # Resource requirements
     #
     addOptionFn = addGroupFn("toil options for cores/memory requirements",
                              "The options to specify default cores/memory requirements (if not "
@@ -440,7 +449,7 @@ def _addOptions(addGroupFn, config):
                 help='The default amount of memory to request for a job. Only applicable to jobs '
                      'that do not specify an explicit value for this requirement. Standard '
                      'suffixes like K, Ki, M, Mi, G or Gi are supported. Default is %s' %
-                     bytes2human( config.defaultMemory, symbols='iec' ))
+                     bytes2human(config.defaultMemory, symbols='iec'))
     addOptionFn('--defaultCores', dest='defaultCores', default=None, metavar='FLOAT',
                 help='The default number of CPU cores to dedicate a job. Only applicable to jobs '
                      'that do not specify an explicit value for this requirement. Fractions of a '
@@ -450,7 +459,7 @@ def _addOptions(addGroupFn, config):
                 help='The default amount of disk space to dedicate a job. Only applicable to jobs '
                      'that do not specify an explicit value for this requirement. Standard '
                      'suffixes like K, Ki, M, Mi, G or Gi are supported. Default is %s' %
-                     bytes2human( config.defaultDisk, symbols='iec' ))
+                     bytes2human(config.defaultDisk, symbols='iec'))
     assert not config.defaultPreemptable, 'User would be unable to reset config.defaultPreemptable'
     addOptionFn('--defaultPreemptable', dest='defaultPreemptable', action='store_true')
     addOptionFn("--readGlobalFileMutableByDefault", dest="readGlobalFileMutableByDefault",
@@ -466,32 +475,32 @@ def _addOptions(addGroupFn, config):
     addOptionFn('--maxMemory', dest='maxMemory', default=None, metavar='INT',
                 help="The maximum amount of memory to request from the batch system at any one "
                      "time. Standard suffixes like K, Ki, M, Mi, G or Gi are supported. Default "
-                     "is %s" % bytes2human( config.maxMemory, symbols='iec'))
+                     "is %s" % bytes2human(config.maxMemory, symbols='iec'))
     addOptionFn('--maxDisk', dest='maxDisk', default=None, metavar='INT',
                 help='The maximum amount of disk space to request from the batch system at any '
                      'one time. Standard suffixes like K, Ki, M, Mi, G or Gi are supported. '
                      'Default is %s' % bytes2human(config.maxDisk, symbols='iec'))
 
     #
-    #Retrying/rescuing jobs
+    # Retrying/rescuing jobs
     #
     addOptionFn = addGroupFn("toil options for rescuing/killing/restarting jobs", \
-            "The options for jobs that either run too long/fail or get lost \
+                             "The options for jobs that either run too long/fail or get lost \
             (some batch systems have issues!)")
     addOptionFn("--retryCount", dest="retryCount", default=None,
-                      help=("Number of times to retry a failing job before giving up and "
-                            "labeling job failed. default=%s" % config.retryCount))
+                help=("Number of times to retry a failing job before giving up and "
+                      "labeling job failed. default=%s" % config.retryCount))
     addOptionFn("--maxJobDuration", dest="maxJobDuration", default=None,
-                      help=("Maximum runtime of a job (in seconds) before we kill it "
-                            "(this is a lower bound, and the actual time before killing "
-                            "the job may be longer). default=%s" % config.maxJobDuration))
+                help=("Maximum runtime of a job (in seconds) before we kill it "
+                      "(this is a lower bound, and the actual time before killing "
+                      "the job may be longer). default=%s" % config.maxJobDuration))
     addOptionFn("--rescueJobsFrequency", dest="rescueJobsFrequency", default=None,
-                      help=("Period of time to wait (in seconds) between checking for "
-                            "missing/overlong jobs, that is jobs which get lost by the batch "
-                            "system. Expert parameter. default=%s" % config.rescueJobsFrequency))
+                help=("Period of time to wait (in seconds) between checking for "
+                      "missing/overlong jobs, that is jobs which get lost by the batch "
+                      "system. Expert parameter. default=%s" % config.rescueJobsFrequency))
 
     #
-    #Misc options
+    # Misc options
     #
     addOptionFn = addGroupFn("toil miscellaneous options", "Miscellaneous options")
     addOptionFn('--disableCaching', dest='disableCaching', action='store_true', default=False,
@@ -519,11 +528,11 @@ def _addOptions(addGroupFn, config):
                 help="Enable real-time logging from workers to masters")
 
     addOptionFn("--sseKey", dest="sseKey", default=None,
-            help="Path to file containing 32 character key to be used for server-side encryption on awsJobStore. SSE will "
-                 "not be used if this flag is not passed.")
+                help="Path to file containing 32 character key to be used for server-side encryption on awsJobStore. SSE will "
+                     "not be used if this flag is not passed.")
     addOptionFn("--cseKey", dest="cseKey", default=None,
                 help="Path to file containing 256-bit key to be used for client-side encryption on "
-                "azureJobStore. By default, no encryption is used.")
+                     "azureJobStore. By default, no encryption is used.")
     addOptionFn("--setEnv", '-e', metavar='NAME=VALUE or NAME',
                 dest="environment", default=[], action="append",
                 help="Set an environment variable early on in the worker. If VALUE is omitted, "
@@ -533,20 +542,22 @@ def _addOptions(addGroupFn, config):
                      "worker process itself before it is started.")
     addOptionFn("--servicePollingInterval", dest="servicePollingInterval", default=None,
                 help="Interval of time service jobs wait between polling for the existence"
-                " of the keep-alive flag (defailt=%s)" % config.servicePollingInterval)
+                     " of the keep-alive flag (defailt=%s)" % config.servicePollingInterval)
     #
-    #Debug options
+    # Debug options
     #
     addOptionFn = addGroupFn("toil debug options", "Debug options")
     addOptionFn("--debug-worker", default=False, action="store_true",
-            help="Experimental no forking mode for local debugging."
-                 " Specifically, workers are not forked and"
-                 " stderr/stdout are not redirected to the log.")
+                help="Experimental no forking mode for local debugging."
+                     " Specifically, workers are not forked and"
+                     " stderr/stdout are not redirected to the log.")
     addOptionFn("--badWorker", dest="badWorker", default=None,
-                      help=("For testing purposes randomly kill 'badWorker' proportion of jobs using SIGKILL, default=%s" % config.badWorker))
+                help=(
+                    "For testing purposes randomly kill 'badWorker' proportion of jobs using SIGKILL, default=%s" % config.badWorker))
     addOptionFn("--badWorkerFailInterval", dest="badWorkerFailInterval", default=None,
-                      help=("When killing the job pick uniformly within the interval from 0.0 to "
-                            "'badWorkerFailInterval' seconds after the worker starts, default=%s" % config.badWorkerFailInterval))
+                help=("When killing the job pick uniformly within the interval from 0.0 to "
+                      "'badWorkerFailInterval' seconds after the worker starts, default=%s" % config.badWorkerFailInterval))
+
 
 def addOptions(parser, config=Config()):
     """
@@ -554,14 +565,16 @@ def addOptions(parser, config=Config()):
     """
     # Wrapper function that allows toil to be used with both the optparse and
     # argparse option parsing modules
-    addLoggingOptions(parser) # This adds the logging stuff.
+    addLoggingOptions(parser)  # This adds the logging stuff.
     if isinstance(parser, ArgumentParser):
         def addGroup(headingString, bodyString):
             return parser.add_argument_group(headingString, bodyString).add_argument
+
         _addOptions(addGroup, config)
     else:
         raise RuntimeError("Unanticipated class passed to addOptions(), %s. Expecting "
                            "argparse.ArgumentParser" % parser.__class__)
+
 
 def getNodeID(extraIDFiles=None):
     """
@@ -586,15 +599,15 @@ def getNodeID(extraIDFiles=None):
                 with open(idSourceFile, "r") as inp:
                     nodeID = inp.readline().strip()
             except EnvironmentError:
-                logger.warning(("Exception when trying to read ID file {}. Will try next method to get node ID").\
-                        format(idSourceFile), exc_info=True)
+                logger.warning(("Exception when trying to read ID file {}. Will try next method to get node ID"). \
+                               format(idSourceFile), exc_info=True)
             else:
                 if len(nodeID.split()) == 1:
-                    logger.debug("Obtained node ID {} from file {}".format(nodeID,idSourceFile))
+                    logger.debug("Obtained node ID {} from file {}".format(nodeID, idSourceFile))
                     break
                 else:
-                    logger.warning(("Node ID {} from file {} contains spaces. Will try next method to get node ID").\
-                            format(nodeID, idSourceFile))
+                    logger.warning(("Node ID {} from file {} contains spaces. Will try next method to get node ID"). \
+                                   format(nodeID, idSourceFile))
     else:
         nodeIDs = []
         for i_call in range(2):
@@ -608,15 +621,16 @@ def getNodeID(extraIDFiles=None):
             if nodeIDs[0] == nodeIDs[1]:
                 nodeID = nodeIDs[0]
             else:
-                logger.warning("Different node IDs {} received from repeated calls to uuid.getnode(). You should use "\
-                        "another method to generate node ID.".format(nodeIDs))
+                logger.warning("Different node IDs {} received from repeated calls to uuid.getnode(). You should use " \
+                               "another method to generate node ID.".format(nodeIDs))
 
             logger.debug("Obtained node ID {} from uuid.getnode()".format(nodeID))
     if not nodeID:
-        logger.warning("Failed to generate stable node ID, returning empty string. If you see this message with a "\
-                "work dir on a shared file system when using workers running on multiple nodes, you might experience "\
-                "cryptic job failures")
+        logger.warning("Failed to generate stable node ID, returning empty string. If you see this message with a " \
+                       "work dir on a shared file system when using workers running on multiple nodes, you might experience " \
+                       "cryptic job failures")
     return nodeID
+
 
 class Toil(object):
     """
@@ -1026,6 +1040,7 @@ class Toil(object):
         if not self._inContextManager:
             raise ToilContextManagerException()
 
+
 class ToilRestartException(Exception):
     def __init__(self, message):
         super(ToilRestartException, self).__init__(message)
@@ -1035,6 +1050,7 @@ class ToilContextManagerException(Exception):
     def __init__(self):
         super(ToilContextManagerException, self).__init__(
             'This method cannot be called outside the "with Toil(...)" context manager.')
+
 
 # Nested functions can't have doctests so we have to make this global
 
@@ -1086,6 +1102,7 @@ def iC(minValue, maxValue=sys.maxsize):
     # Returns function that checks if a given int is in the given half-open interval
     assert isinstance(minValue, int) and isinstance(maxValue, int)
     return lambda x: minValue <= x < maxValue
+
 
 def fC(minValue, maxValue=None):
     # Returns function that checks if a given float is in the given half-open interval

--- a/src/toil/fileStore.py
+++ b/src/toil/fileStore.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import, print_function
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import map
 from builtins import str
@@ -63,6 +64,7 @@ class DeferredFunction(namedtuple('DeferredFunction', 'function args kwargs name
     >>> df.invoke() == defaultdict(None, x=1, y=2)
     True
     """
+
     @classmethod
     def create(cls, function, *args, **kwargs):
         """
@@ -276,6 +278,7 @@ class FileStore(with_metaclass(ABCMeta, object)):
         """
         Utility class to read and write dill-ed state dictionaries from/to a file into a namespace.
         """
+
         def __init__(self, stateDict):
             assert isinstance(stateDict, dict)
             self.__dict__.update(stateDict)
@@ -541,7 +544,7 @@ class CachingFileStore(FileStore):
             # the two have distinct nlink counts.
             # Can read without a lock because we're only reading job-specific info.
             jobSpecificFiles = list(self._CacheState._load(self.cacheStateFile).jobState[
-                self.jobID]['filesToFSIDs'].keys())
+                                        self.jobID]['filesToFSIDs'].keys())
             # Saying nlink is 2 implicitly means we are using the job file store, and it is on
             # the same device as the work dir.
             if self.nlinkThreshold == 2 and absLocalFileName not in jobSpecificFiles:
@@ -1120,7 +1123,7 @@ class CachingFileStore(FileStore):
                 'jobName': self.jobName,
                 'jobReqs': newJobReqs,
                 'jobDir': self.localTempDir,
-                'jobSpecificFiles': defaultdict(partial(defaultdict,int)),
+                'jobSpecificFiles': defaultdict(partial(defaultdict, int)),
                 'filesToFSIDs': defaultdict(set),
                 'pid': os.getpid(),
                 'deferredFunctions': []}
@@ -1236,6 +1239,7 @@ class CachingFileStore(FileStore):
         caching equation is balanced or not.  It extends the _StateFile class to add other cache
         related functions.
         """
+
         @classmethod
         @contextmanager
         def open(cls, outer=None):
@@ -1845,6 +1849,7 @@ class FileID(str):
     A class to wrap the job store file id returned by writeGlobalFile and any attributes we may want
     to add to it.
     """
+
     def __new__(cls, fileStoreID, *args):
         return super(FileID, cls).__new__(cls, fileStoreID)
 

--- a/src/toil/jobStores/abstractJobStore.py
+++ b/src/toil/jobStores/abstractJobStore.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import str
 from builtins import map
@@ -60,6 +61,7 @@ class InvalidImportExportUrlException(Exception):
 
 class NoSuchJobException(Exception):
     """Indicates that the specified job does not exist."""
+
     def __init__(self, jobStoreID):
         """
         :param str jobStoreID: the jobStoreID that was mistakenly assumed to exist
@@ -69,6 +71,7 @@ class NoSuchJobException(Exception):
 
 class ConcurrentFileModificationException(Exception):
     """Indicates that the file was attempted to be modified by multiple processes at once."""
+
     def __init__(self, jobStoreFileID):
         """
         :param str jobStoreFileID: the ID of the file that was modified by multiple workers
@@ -80,6 +83,7 @@ class ConcurrentFileModificationException(Exception):
 
 class NoSuchFileException(Exception):
     """Indicates that the specified file does not exist."""
+
     def __init__(self, jobStoreFileID, customName=None):
         """
         :param str jobStoreFileID: the ID of the file that was mistakenly assumed to exist
@@ -94,6 +98,7 @@ class NoSuchFileException(Exception):
 
 class NoSuchJobStoreException(Exception):
     """Indicates that the specified job store does not exist."""
+
     def __init__(self, locator):
         super(NoSuchJobStoreException, self).__init__(
             "The job store '%s' does not exist, so there is nothing to restart" % locator)
@@ -101,6 +106,7 @@ class NoSuchJobStoreException(Exception):
 
 class JobStoreExistsException(Exception):
     """Indicates that the specified job store already exists."""
+
     def __init__(self, locator):
         super(JobStoreExistsException, self).__init__(
             "The job store '%s' already exists. Use --restart to resume the workflow, or remove "
@@ -484,8 +490,7 @@ class AbstractJobStore(with_metaclass(ABCMeta, object)):
             # Traverse jobs in stack
             for jobs in jobGraph.stack:
                 for successorJobStoreID in [x.jobStoreID for x in jobs]:
-                    if (successorJobStoreID not in reachableFromRoot
-                        and haveJob(successorJobStoreID)):
+                    if (successorJobStoreID not in reachableFromRoot and haveJob(successorJobStoreID)):
                         getConnectedJobs(getJob(successorJobStoreID))
             # Traverse service jobs
             for jobs in jobGraph.services:
@@ -598,9 +603,12 @@ class AbstractJobStore(with_metaclass(ABCMeta, object)):
             startServicesSize = servicesSizeFn()
 
             def replaceFlagsIfNeeded(serviceJobNode):
-                serviceJobNode.startJobStoreID = subFlagFile(serviceJobNode.jobStoreID, serviceJobNode.startJobStoreID, 1)
-                serviceJobNode.terminateJobStoreID = subFlagFile(serviceJobNode.jobStoreID, serviceJobNode.terminateJobStoreID, 2)
-                serviceJobNode.errorJobStoreID = subFlagFile(serviceJobNode.jobStoreID, serviceJobNode.errorJobStoreID, 3)
+                serviceJobNode.startJobStoreID = subFlagFile(serviceJobNode.jobStoreID, serviceJobNode.startJobStoreID,
+                                                             1)
+                serviceJobNode.terminateJobStoreID = subFlagFile(serviceJobNode.jobStoreID,
+                                                                 serviceJobNode.terminateJobStoreID, 2)
+                serviceJobNode.errorJobStoreID = subFlagFile(serviceJobNode.jobStoreID, serviceJobNode.errorJobStoreID,
+                                                             3)
 
             # jobGraph.services is a list of lists containing serviceNodes
             # remove all services that no longer exist
@@ -634,12 +642,14 @@ class AbstractJobStore(with_metaclass(ABCMeta, object)):
 
         # Remove any crufty stats/logging files from the previous run
         logger.info("Discarding old statistics and logs...")
+
         # We have to manually discard the stream to avoid getting
         # stuck on a blocking write from the job store.
         def discardStream(stream):
             """Read the stream 4K at a time until EOF, discarding all input."""
             while len(stream.read(4096)) != 0:
                 pass
+
         self.readStatsAndLogging(discardStream)
 
         logger.info("Job store is clean")

--- a/src/toil/jobStores/aws/utils.py
+++ b/src/toil/jobStores/aws/utils.py
@@ -34,7 +34,6 @@ from multiprocessing import cpu_count
 # Python 3 compatibility imports
 import itertools
 
-
 import boto
 from bd2k.util.exceptions import panic
 from concurrent.futures import ThreadPoolExecutor

--- a/src/toil/jobStores/azureJobStore.py
+++ b/src/toil/jobStores/azureJobStore.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import str
 from builtins import range

--- a/src/toil/jobStores/fileJobStore.py
+++ b/src/toil/jobStores/fileJobStore.py
@@ -43,7 +43,7 @@ from toil.jobStores.abstractJobStore import (AbstractJobStore,
                                              NoSuchJobStoreException)
 from toil.jobGraph import JobGraph
 
-logger = logging.getLogger( __name__ )
+logger = logging.getLogger(__name__)
 
 
 class FileJobStore(AbstractJobStore):
@@ -82,7 +82,7 @@ class FileJobStore(AbstractJobStore):
     def resume(self):
         if not os.path.exists(self.jobStoreDir):
             raise NoSuchJobStoreException(self.jobStoreDir)
-        require( os.path.isdir, "'%s' is not a directory", self.jobStoreDir)
+        require(os.path.isdir, "'%s' is not a directory", self.jobStoreDir)
         super(FileJobStore, self).resume()
 
     def destroy(self):
@@ -168,7 +168,7 @@ class FileJobStore(AbstractJobStore):
         # Walk through list of temporary directories searching for jobs
         for tempDir in self._tempDirectories():
             for i in os.listdir(tempDir):
-                if i.startswith( 'job' ):
+                if i.startswith('job'):
                     try:
                         yield self.load(self._getRelativePath(os.path.join(tempDir, i)))
                     except NoSuchJobException:
@@ -327,19 +327,19 @@ class FileJobStore(AbstractJobStore):
     @contextmanager
     def writeSharedFileStream(self, sharedFileName, isProtected=None):
         # the isProtected parameter has no effect on the fileStore
-        assert self._validateSharedFileName( sharedFileName )
+        assert self._validateSharedFileName(sharedFileName)
         with open(self._getSharedFilePath(sharedFileName), 'w') as f:
             yield f
 
     @contextmanager
     def readSharedFileStream(self, sharedFileName):
-        assert self._validateSharedFileName( sharedFileName )
+        assert self._validateSharedFileName(sharedFileName)
         try:
             with open(os.path.join(self.jobStoreDir, sharedFileName), 'r') as f:
                 yield f
         except IOError as e:
             if e.errno == errno.ENOENT:
-                raise NoSuchFileException(sharedFileName,sharedFileName)
+                raise NoSuchFileException(sharedFileName, sharedFileName)
             else:
                 raise
 
@@ -386,7 +386,7 @@ class FileJobStore(AbstractJobStore):
         self.tempFilesDir
 
         """
-        return absPath[len(self.tempFilesDir)+1:]
+        return absPath[len(self.tempFilesDir) + 1:]
 
     def _getJobFileName(self, jobStoreID):
         """
@@ -425,7 +425,7 @@ class FileJobStore(AbstractJobStore):
                 try:
                     os.mkdir(tempDir)
                 except os.error:
-                    if not os.path.exists(tempDir): # In the case that a collision occurs and
+                    if not os.path.exists(tempDir):  # In the case that a collision occurs and
                         # it is created while we wait then we ignore
                         raise
         return tempDir
@@ -435,13 +435,15 @@ class FileJobStore(AbstractJobStore):
         :rtype : an iterator to the temporary directories containing jobs/stats files
         in the hierarchy of directories in self.tempFilesDir
         """
+
         def _dirs(path, levels):
             if levels > 0:
                 for subPath in os.listdir(path):
-                    for i in _dirs(os.path.join(path, subPath), levels-1):
+                    for i in _dirs(os.path.join(path, subPath), levels - 1):
                         yield i
             else:
                 yield path
+
         for tempDir in _dirs(self.tempFilesDir, self.levels):
             yield tempDir
 
@@ -456,7 +458,7 @@ class FileJobStore(AbstractJobStore):
             # Make a temporary file within the job's directory
             self._checkJobStoreId(jobStoreID)
             return tempfile.mkstemp(suffix=".tmp",
-                                dir=os.path.join(self._getAbsPath(jobStoreID), "g"))
+                                    dir=os.path.join(self._getAbsPath(jobStoreID), "g"))
         else:
             # Make a temporary file within the temporary file structure
             return tempfile.mkstemp(prefix="tmp", suffix=".tmp", dir=self._getTempSharedDir())

--- a/src/toil/jobStores/googleJobStore.py
+++ b/src/toil/jobStores/googleJobStore.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import str
 import base64
@@ -46,7 +47,6 @@ GOOGLE_STORAGE = 'gs'
 
 
 class GoogleJobStore(AbstractJobStore):
-
     @classmethod
     def initialize(cls, locator, config=None):
         try:
@@ -80,15 +80,15 @@ class GoogleJobStore(AbstractJobStore):
         #  create 2 buckets
         self.projectID = projectID
 
-        self.bucketName = namePrefix+"--toil"
+        self.bucketName = namePrefix + "--toil"
         log.debug("Instantiating google jobStore with name: %s", self.bucketName)
-        self.gsBucketURL = "gs://"+self.bucketName
+        self.gsBucketURL = "gs://" + self.bucketName
 
         self._headerValues = {"x-goog-project-id": bytes(projectID)} if projectID else {}
 
         # Not reading .boto correctly, this works to create bucket after 'pip install gsutils', which updates osauth2
-        #import gcs_oauth2_boto_plugin
-        #gcs_oauth2_boto_plugin.SetFallbackClientIdAndSecret(gs_access_key_id, gs_secret_access_key)
+        # import gcs_oauth2_boto_plugin
+        # gcs_oauth2_boto_plugin.SetFallbackClientIdAndSecret(gs_access_key_id, gs_secret_access_key)
 
         self._encryptedHeaders = self.headerValues
 
@@ -111,7 +111,7 @@ class GoogleJobStore(AbstractJobStore):
 
         self.statsBaseID = 'f16eef0c-b597-4b8b-9b0c-4d605b4f506c'
         self.statsReadPrefix = '_'
-        self.readStatsBaseID = self.statsReadPrefix+self.statsBaseID
+        self.readStatsBaseID = self.statsReadPrefix + self.statsBaseID
 
     def destroy(self):
         # no upper time limit on this call keep trying delete calls until we succeed - we can
@@ -271,7 +271,7 @@ class GoogleJobStore(AbstractJobStore):
     def _getResources(url):
         projectID = url.host
         bucketAndKey = url.path
-        return projectID, 'gs://'+bucketAndKey
+        return projectID, 'gs://' + bucketAndKey
 
     @classmethod
     def getSize(cls, url):
@@ -337,7 +337,7 @@ class GoogleJobStore(AbstractJobStore):
                 if lastTry:
                     # this was our second try, we are reasonably sure there aren't any stats
                     # left to gather
-                        break
+                    break
                 # Try one more time in a couple seconds
                 time.sleep(5)
                 lastTry = True
@@ -365,11 +365,11 @@ class GoogleJobStore(AbstractJobStore):
     @staticmethod
     def _newID(isFile=False, jobStoreID=None):
         if isFile and jobStoreID:  # file associated with job
-            return jobStoreID+str(uuid.uuid4())
+            return jobStoreID + str(uuid.uuid4())
         elif isFile:  # nonassociated file
             return str(uuid.uuid4())
         else:  # job id
-            return "job"+str(uuid.uuid4())
+            return "job" + str(uuid.uuid4())
 
     def _resolveEncryptionHeaders(self):
         sseKeyPath = self.sseKeyPath

--- a/src/toil/jobStores/utils.py
+++ b/src/toil/jobStores/utils.py
@@ -10,6 +10,7 @@ from future.utils import with_metaclass
 
 log = logging.getLogger(__name__)
 
+
 class WritablePipe(with_metaclass(ABCMeta, object)):
     """
     An object-oriented wrapper for os.pipe. Clients should subclass it, implement

--- a/src/toil/leader.py
+++ b/src/toil/leader.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import str
 from builtins import object
@@ -38,6 +39,7 @@ from bd2k.util.expando import Expando
 from bd2k.util.humanize import bytes2human
 
 from toil import resolveEntryPoint
+
 try:
     from toil.cwl.cwltoil import CWL_INTERNAL_JOBS
 except ImportError:
@@ -50,13 +52,14 @@ from toil.statsAndLogging import StatsAndLogging
 from toil.job import JobNode, ServiceJobNode
 from toil.toilState import ToilState
 
-logger = logging.getLogger( __name__ )
+logger = logging.getLogger(__name__)
+
 
 ####################################################
 # Exception thrown by the Leader class when one or more jobs fails
 ####################################################
 
-class FailedJobsException( Exception ):
+class FailedJobsException(Exception):
     def __init__(self, jobStoreLocator, failedJobs, jobStore):
         msg = "The job store '%s' contains %i failed jobs" % (jobStoreLocator, len(failedJobs))
         try:
@@ -71,19 +74,21 @@ class FailedJobsException( Exception ):
         # catch failures to prepare more complex details and only return the basics
         except:
             logger.exception('Exception when compiling information about failed jobs')
-        super( FailedJobsException, self ).__init__(msg)
+        super(FailedJobsException, self).__init__(msg)
         self.jobStoreLocator = jobStoreLocator
         self.numberOfFailedJobs = len(failedJobs)
+
 
 ####################################################
 # Exception thrown by the Leader class when a deadlock is encountered due to insufficient
 # resources to run the workflow
 ####################################################
 
-class DeadlockException( Exception ):
+class DeadlockException(Exception):
     def __init__(self, msg):
         msg = "Deadlock encountered: " + msg
-        super( DeadlockException, self ).__init__(msg)
+        super(DeadlockException, self).__init__(msg)
+
 
 ####################################################
 ##Following class represents the leader
@@ -92,6 +97,7 @@ class DeadlockException( Exception ):
 class Leader(object):
     """ Class that encapsulates the logic of the leader.
     """
+
     def __init__(self, config, batchSystem, provisioner, jobStore, rootJob, jobCache=None):
         """
         :param toil.common.Config config:
@@ -114,11 +120,11 @@ class Leader(object):
         # Get a snap shot of the current state of the jobs in the jobStore
         self.toilState = ToilState(jobStore, rootJob, jobCache=jobCache)
         logger.info("Found %s jobs to start and %i jobs with successors to run",
-                        len(self.toilState.updatedJobs), len(self.toilState.successorCounts))
+                    len(self.toilState.updatedJobs), len(self.toilState.successorCounts))
 
         # Batch system
         self.batchSystem = batchSystem
-        assert len(self.batchSystem.getIssuedBatchJobIDs()) == 0 #Batch system must start with no active jobs!
+        assert len(self.batchSystem.getIssuedBatchJobIDs()) == 0  # Batch system must start with no active jobs!
         logger.info("Checked batch system has no running jobs and no updated jobs")
 
         # Map of batch system IDs to IsseudJob tuples
@@ -130,8 +136,8 @@ class Leader(object):
         # Tracking the number service jobs issued,
         # this is used limit the number of services issued to the batch system
         self.serviceJobsIssued = 0
-        self.serviceJobsToBeIssued = [] # A queue of service jobs that await scheduling
-        #Equivalents for service jobs to be run on preemptable nodes
+        self.serviceJobsToBeIssued = []  # A queue of service jobs that await scheduling
+        # Equivalents for service jobs to be run on preemptable nodes
         self.preemptableServiceJobsIssued = 0
         self.preemptableServiceJobsToBeIssued = []
 
@@ -142,7 +148,7 @@ class Leader(object):
         # Class used to create/destroy nodes in the cluster, may be None if
         # using a statically defined cluster
         self.provisioner = provisioner
- 
+
         # Create cluster scaling thread if the provisioner is not None
         self.clusterScaler = None if self.provisioner is None else ClusterScaler(self.provisioner, self, self.config)
 
@@ -197,17 +203,19 @@ class Leader(object):
             self.statsAndLogging.shutdown()
 
         # Filter the failed jobs
-        self.toilState.totalFailedJobs = [j for j in self.toilState.totalFailedJobs if self.jobStore.exists(j.jobStoreID)]
+        self.toilState.totalFailedJobs = [j for j in self.toilState.totalFailedJobs if
+                                          self.jobStore.exists(j.jobStoreID)]
 
         logger.info("Finished toil run %s" %
-                     ("successfully" if len(self.toilState.totalFailedJobs) == 0 else ("with %s failed jobs" % len(self.toilState.totalFailedJobs))))
+                    ("successfully" if len(self.toilState.totalFailedJobs) == 0 else (
+                        "with %s failed jobs" % len(self.toilState.totalFailedJobs))))
 
         if len(self.toilState.totalFailedJobs):
-            logger.info("Failed jobs at end of the run: %s", ' '.join(str(job) for job in self.toilState.totalFailedJobs))
+            logger.info("Failed jobs at end of the run: %s",
+                        ' '.join(str(job) for job in self.toilState.totalFailedJobs))
         # Cleanup
         if len(self.toilState.totalFailedJobs) > 0:
             raise FailedJobsException(self.config.jobStore, self.toilState.totalFailedJobs, self.jobStore)
-
 
         return self.jobStore.getRootJobReturnValue()
 
@@ -225,8 +233,8 @@ class Leader(object):
                 logger.debug('Built the jobs list, currently have %i jobs to update and %i jobs issued',
                              len(self.toilState.updatedJobs), self.getNumberOfJobsIssued())
 
-                updatedJobs = self.toilState.updatedJobs # The updated jobs to consider below
-                self.toilState.updatedJobs = set() # Resetting the list for the next set
+                updatedJobs = self.toilState.updatedJobs  # The updated jobs to consider below
+                self.toilState.updatedJobs = set()  # Resetting the list for the next set
 
                 for jobGraph, resultStatus in updatedJobs:
 
@@ -253,7 +261,7 @@ class Leader(object):
                             logger.debug("Telling job: %s to terminate its services due to successor failure",
                                          jobGraph.jobStoreID)
                             self.serviceManager.killServices(self.toilState.servicesIssued[jobGraph.jobStoreID],
-                                                        error=True)
+                                                             error=True)
 
                         # If the job has non-service jobs running wait for them to finish
                         # the job will be re-added to the updated jobs when these jobs are done
@@ -271,7 +279,7 @@ class Leader(object):
                             logger.warn('Job: %s is being restarted as a checkpoint after the total '
                                         'failure of jobs in its subtree.', jobGraph.jobStoreID)
                             self.issueJob(JobNode.fromJobGraph(jobGraph))
-                        else: # Mark it totally failed
+                        else:  # Mark it totally failed
                             logger.debug("Job %s is being processed as completely failed", jobGraph.jobStoreID)
                             self.processTotallyFailedJob(jobGraph)
 
@@ -315,21 +323,21 @@ class Leader(object):
                         assert len(jobGraph.stack[-1]) > 0
                         logger.debug("Job: %s has %i successors to schedule",
                                      jobGraph.jobStoreID, len(jobGraph.stack[-1]))
-                        #Record the number of successors that must be completed before
-                        #the jobGraph can be considered again
+                        # Record the number of successors that must be completed before
+                        # the jobGraph can be considered again
                         assert jobGraph.jobStoreID not in self.toilState.successorCounts
                         self.toilState.successorCounts[jobGraph.jobStoreID] = len(jobGraph.stack[-1])
-                        #List of successors to schedule
+                        # List of successors to schedule
                         successors = []
 
-                        #For each successor schedule if all predecessors have been completed
+                        # For each successor schedule if all predecessors have been completed
                         for jobNode in jobGraph.stack[-1]:
                             successorJobStoreID = jobNode.jobStoreID
-                            #Build map from successor to predecessors.
+                            # Build map from successor to predecessors.
                             if successorJobStoreID not in self.toilState.successorJobStoreIDToPredecessorJobs:
                                 self.toilState.successorJobStoreIDToPredecessorJobs[successorJobStoreID] = []
                             self.toilState.successorJobStoreIDToPredecessorJobs[successorJobStoreID].append(jobGraph)
-                            #Case that the jobGraph has multiple predecessors
+                            # Case that the jobGraph has multiple predecessors
                             if jobNode.predecessorNumber > 1:
                                 logger.debug("Successor job: %s of job: %s has multiple "
                                              "predecessors", jobNode, jobGraph)
@@ -338,10 +346,12 @@ class Leader(object):
                                 # (if the successor job has already been seen it will be in this cache,
                                 # but otherwise put it in the cache)
                                 if successorJobStoreID not in self.toilState.jobsToBeScheduledWithMultiplePredecessors:
-                                    self.toilState.jobsToBeScheduledWithMultiplePredecessors[successorJobStoreID] = self.jobStore.load(successorJobStoreID)
-                                successorJobGraph = self.toilState.jobsToBeScheduledWithMultiplePredecessors[successorJobStoreID]
+                                    self.toilState.jobsToBeScheduledWithMultiplePredecessors[
+                                        successorJobStoreID] = self.jobStore.load(successorJobStoreID)
+                                successorJobGraph = self.toilState.jobsToBeScheduledWithMultiplePredecessors[
+                                    successorJobStoreID]
 
-                                #Add the jobGraph as a finished predecessor to the successor
+                                # Add the jobGraph as a finished predecessor to the successor
                                 successorJobGraph.predecessorsFinished.add(jobGraph.jobStoreID)
 
                                 # If the successor is in the set of successors of failed jobs
@@ -355,8 +365,10 @@ class Leader(object):
                                     # Reduce active successor count and remove the successor as an active successor of the job
                                     self.toilState.successorCounts[jobGraph.jobStoreID] -= 1
                                     assert self.toilState.successorCounts[jobGraph.jobStoreID] >= 0
-                                    self.toilState.successorJobStoreIDToPredecessorJobs[successorJobStoreID].remove(jobGraph)
-                                    if len(self.toilState.successorJobStoreIDToPredecessorJobs[successorJobStoreID]) == 0:
+                                    self.toilState.successorJobStoreIDToPredecessorJobs[successorJobStoreID].remove(
+                                        jobGraph)
+                                    if len(self.toilState.successorJobStoreIDToPredecessorJobs[
+                                               successorJobStoreID]) == 0:
                                         self.toilState.successorJobStoreIDToPredecessorJobs.pop(successorJobStoreID)
 
                                     # If the job now has no active successors add to active jobs
@@ -371,7 +383,8 @@ class Leader(object):
 
                                 # If the successor job's predecessors have all not all completed then
                                 # ignore the jobGraph as is not yet ready to run
-                                assert len(successorJobGraph.predecessorsFinished) <= successorJobGraph.predecessorNumber
+                                assert len(
+                                    successorJobGraph.predecessorsFinished) <= successorJobGraph.predecessorNumber
                                 if len(successorJobGraph.predecessorsFinished) < successorJobGraph.predecessorNumber:
                                     continue
                                 else:
@@ -386,15 +399,16 @@ class Leader(object):
                         logger.debug("Telling job: %s to terminate its services due to the "
                                      "successful completion of its successor jobs",
                                      jobGraph)
-                        self.serviceManager.killServices(self.toilState.servicesIssued[jobGraph.jobStoreID], error=False)
+                        self.serviceManager.killServices(self.toilState.servicesIssued[jobGraph.jobStoreID],
+                                                         error=False)
 
-                    #There are no remaining tasks to schedule within the jobGraph, but
-                    #we schedule it anyway to allow it to be deleted.
+                    # There are no remaining tasks to schedule within the jobGraph, but
+                    # we schedule it anyway to allow it to be deleted.
 
-                    #TODO: An alternative would be simple delete it here and add it to the
-                    #list of jobs to process, or (better) to create an asynchronous
-                    #process that deletes jobs and then feeds them back into the set
-                    #of jobs to be processed
+                    # TODO: An alternative would be simple delete it here and add it to the
+                    # list of jobs to process, or (better) to create an asynchronous
+                    # process that deletes jobs and then feeds them back into the set
+                    # of jobs to be processed
                     else:
                         # Remove the job
                         if jobGraph.remainingRetryCount > 0:
@@ -402,7 +416,8 @@ class Leader(object):
                             logger.debug("Job: %s is empty, we are scheduling to clean it up", jobGraph.jobStoreID)
                         else:
                             self.processTotallyFailedJob(jobGraph)
-                            logger.warn("Job: %s is empty but completely failed - something is very wrong", jobGraph.jobStoreID)
+                            logger.warn("Job: %s is empty but completely failed - something is very wrong",
+                                        jobGraph.jobStoreID)
 
             # Start any service jobs available from the service manager
             self.issueQueingServiceJobs()
@@ -417,7 +432,7 @@ class Leader(object):
             # Get jobs whose services have started
             while True:
                 jobGraph = self.serviceManager.getJobGraphWhoseServicesAreRunning(0)
-                if jobGraph is None: # Stop trying to get jobs when function returns None
+                if jobGraph is None:  # Stop trying to get jobs when function returns None
                     break
                 logger.debug('Job: %s has established its services.', jobGraph.jobStoreID)
                 jobGraph.services = []
@@ -446,15 +461,15 @@ class Leader(object):
             else:
                 # Process jobs that have gone awry
 
-                #In the case that there is nothing happening
-                #(no updated jobs to gather for 10 seconds)
-                #check if there are any jobs that have run too long
-                #(see self.reissueOverLongJobs) or which
-                #have gone missing from the batch system (see self.reissueMissingJobs)
+                # In the case that there is nothing happening
+                # (no updated jobs to gather for 10 seconds)
+                # check if there are any jobs that have run too long
+                # (see self.reissueOverLongJobs) or which
+                # have gone missing from the batch system (see self.reissueMissingJobs)
                 if (time.time() - timeSinceJobsLastRescued >=
-                    self.config.rescueJobsFrequency): #We only
-                    #rescue jobs every N seconds, and when we have
-                    #apparently exhausted the current jobGraph supply
+                        self.config.rescueJobsFrequency):  # We only
+                    # rescue jobs every N seconds, and when we have
+                    # apparently exhausted the current jobGraph supply
                     self.reissueOverLongJobs()
                     logger.info("Reissued any over long jobs")
 
@@ -462,8 +477,8 @@ class Leader(object):
                     if hasNoMissingJobs:
                         timeSinceJobsLastRescued = time.time()
                     else:
-                        timeSinceJobsLastRescued += 60 #This means we'll try again
-                        #in a minute, providing things are quiet
+                        timeSinceJobsLastRescued += 60  # This means we'll try again
+                        # in a minute, providing things are quiet
                     logger.info("Rescued any (long) missing jobs")
 
             # Check on the associated threads and exit if a failure is detected
@@ -474,7 +489,8 @@ class Leader(object):
                 self.clusterScaler.check()
 
             # The exit criterion
-            if len(self.toilState.updatedJobs) == 0 and self.getNumberOfJobsIssued() == 0 and self.serviceManager.jobsIssuedToServiceManager == 0:
+            if len(
+                    self.toilState.updatedJobs) == 0 and self.getNumberOfJobsIssued() == 0 and self.serviceManager.jobsIssuedToServiceManager == 0:
                 logger.info("No jobs left to run so exiting.")
                 break
 
@@ -511,7 +527,8 @@ class Leader(object):
                     self.potentialDeadlockedJobs = runningServiceJobs
                     self.potentialDeadlockTime = time.time()
                 elif time.time() - self.potentialDeadlockTime >= self.config.deadlockWait:
-                    raise DeadlockException("The system is service deadlocked - all %d running jobs are active services" % totalRunningJobs)
+                    raise DeadlockException(
+                        "The system is service deadlocked - all %d running jobs are active services" % totalRunningJobs)
             else:
                 # We have observed non-service jobs running, so reset the potential deadlock
                 self.potentialDeadlockedJobs = set()
@@ -520,7 +537,6 @@ class Leader(object):
             # We have observed non-service jobs running, so reset the potential deadlock
             self.potentialDeadlockedJobs = set()
             self.potentialDeadlockTime = 0
-
 
     def issueJob(self, jobNode):
         """
@@ -566,7 +582,8 @@ class Leader(object):
         while len(self.serviceJobsToBeIssued) > 0 and self.serviceJobsIssued < self.config.maxServiceJobs:
             self.issueJob(self.serviceJobsToBeIssued.pop())
             self.serviceJobsIssued += 1
-        while len(self.preemptableServiceJobsToBeIssued) > 0 and self.preemptableServiceJobsIssued < self.config.maxPreemptableServiceJobs:
+        while len(
+                self.preemptableServiceJobsToBeIssued) > 0 and self.preemptableServiceJobsIssued < self.config.maxPreemptableServiceJobs:
             self.issueJob(self.preemptableServiceJobsToBeIssued.pop())
             self.preemptableServiceJobsIssued += 1
 
@@ -586,7 +603,6 @@ class Leader(object):
         else:
             assert len(self.jobBatchSystemIDToIssuedJob) >= self.preemptableJobsIssued
             return len(self.jobBatchSystemIDToIssuedJob) - self.preemptableJobsIssued
-
 
     def getJobStoreID(self, jobBatchSystemID):
         """
@@ -615,6 +631,7 @@ class Leader(object):
                 self.serviceJobsIssued -= 1
 
         return jobNode
+
     def getJobs(self, preemptable=None):
         jobs = self.jobBatchSystemIDToIssuedJob.values()
         if preemptable is not None:
@@ -636,7 +653,7 @@ class Leader(object):
             for jobBatchSystemID in jobsToKill:
                 self.processFinishedJob(jobBatchSystemID, 1)
 
-    #Following functions handle error cases for when jobs have gone awry with the batch system.
+    # Following functions handle error cases for when jobs have gone awry with the batch system.
 
     def reissueOverLongJobs(self):
         """
@@ -668,13 +685,13 @@ class Leader(object):
         """
         runningJobs = set(self.batchSystem.getIssuedBatchJobIDs())
         jobBatchSystemIDsSet = set(self.getJobIDs())
-        #Clean up the reissueMissingJobs_missingHash hash, getting rid of jobs that have turned up
+        # Clean up the reissueMissingJobs_missingHash hash, getting rid of jobs that have turned up
         missingJobIDsSet = set(self.reissueMissingJobs_missingHash.keys())
         for jobBatchSystemID in missingJobIDsSet.difference(jobBatchSystemIDsSet):
             self.reissueMissingJobs_missingHash.pop(jobBatchSystemID)
             logger.warn("Batch system id: %s is no longer missing", str(jobBatchSystemID))
-        assert runningJobs.issubset(jobBatchSystemIDsSet) #Assert checks we have
-        #no unexpected jobs running
+        assert runningJobs.issubset(jobBatchSystemIDsSet)  # Assert checks we have
+        # no unexpected jobs running
         jobsToKill = []
         for jobBatchSystemID in set(jobBatchSystemIDsSet.difference(runningJobs)):
             jobStoreID = self.getJobStoreID(jobBatchSystemID)
@@ -689,18 +706,20 @@ class Leader(object):
                 self.reissueMissingJobs_missingHash.pop(jobBatchSystemID)
                 jobsToKill.append(jobBatchSystemID)
         self.killJobs(jobsToKill)
-        return len( self.reissueMissingJobs_missingHash ) == 0 #We use this to inform
-        #if there are missing jobs
+        return len(self.reissueMissingJobs_missingHash) == 0  # We use this to inform
+        # if there are missing jobs
 
     def processFinishedJob(self, batchSystemID, resultStatus, wallTime=None):
         """
         Function reads a processed jobGraph file and updates it state.
         """
+
         def processRemovedJob(issuedJob):
             if resultStatus != 0:
                 logger.warn("Despite the batch system claiming failure the "
                             "job %s seems to have finished and been removed", issuedJob)
             self._updatePredecessorStatus(issuedJob.jobStoreID)
+
         jobNode = self.removeJob(batchSystemID)
         jobStoreID = jobNode.jobStoreID
         if wallTime is not None and self.clusterScaler is not None:
@@ -723,7 +742,7 @@ class Leader(object):
                 else:
                     raise
             if jobGraph.logJobStoreFileID is not None:
-                with jobGraph.getLogFileHandle( self.jobStore ) as logFileStream:
+                with jobGraph.getLogFileHandle(self.jobStore) as logFileStream:
                     # more memory efficient than read().striplines() while leaving off the
                     # trailing \n left when using readlines()
                     # http://stackoverflow.com/a/15233739
@@ -744,10 +763,10 @@ class Leader(object):
                 # If the job has completed okay, we can remove it from the list of jobs with failed successors
                 self.toilState.hasFailedSuccessors.remove(jobStoreID)
 
-            self.toilState.updatedJobs.add((jobGraph, resultStatus)) #Now we know the
-            #jobGraph is done we can add it to the list of updated jobGraph files
+            self.toilState.updatedJobs.add((jobGraph, resultStatus))  # Now we know the
+            # jobGraph is done we can add it to the list of updated jobGraph files
             logger.debug("Added job: %s to active jobs", jobGraph)
-        else:  #The jobGraph is done
+        else:  # The jobGraph is done
             processRemovedJob(jobNode)
 
     @staticmethod
@@ -781,7 +800,7 @@ class Leader(object):
                         if jobStore.exists(successorJobStoreID):
                             successorRecursion(jobStore.load(successorJobStoreID))
 
-        successorRecursion(jobGraph) # Recurse from jobGraph
+        successorRecursion(jobGraph)  # Recurse from jobGraph
 
         return successors
 
@@ -792,7 +811,7 @@ class Leader(object):
         # Mark job as a totally failed job
         self.toilState.totalFailedJobs.add(JobNode.fromJobGraph(jobGraph))
 
-        if jobGraph.jobStoreID in self.toilState.serviceJobStoreIDToPredecessorJob: # Is
+        if jobGraph.jobStoreID in self.toilState.serviceJobStoreIDToPredecessorJob:  # Is
             # a service job
             logger.debug("Service job is being processed as a totally failed job: %s", jobGraph)
 
@@ -811,10 +830,11 @@ class Leader(object):
             # terminate. We do this to prevent other services in the set
             # of services from deadlocking waiting for this service to start properly
             if predecesssorJobGraph.jobStoreID in self.toilState.servicesIssued:
-                self.serviceManager.killServices(self.toilState.servicesIssued[predecesssorJobGraph.jobStoreID], error=True)
+                self.serviceManager.killServices(self.toilState.servicesIssued[predecesssorJobGraph.jobStoreID],
+                                                 error=True)
                 logger.debug("Job: %s is instructing all the services of its parent job to quit", jobGraph)
 
-            self.toilState.hasFailedSuccessors.add(predecesssorJobGraph.jobStoreID) # This ensures that the
+            self.toilState.hasFailedSuccessors.add(predecesssorJobGraph.jobStoreID)  # This ensures that the
             # job will not attempt to run any of it's successors on the stack
         else:
             # Is a non-service job
@@ -827,7 +847,7 @@ class Leader(object):
             unseenSuccessors = self.getSuccessors(jobGraph, self.toilState.failedSuccessors,
                                                   self.jobStore)
             logger.debug("Found new failed successors: %s of job: %s", " ".join(
-                         unseenSuccessors), jobGraph)
+                unseenSuccessors), jobGraph)
 
             # For each newly found successor
             for successorJobStoreID in unseenSuccessors:
@@ -861,7 +881,6 @@ class Leader(object):
 
                 # For each predecessor of the job
                 for predecessorJobGraph in self.toilState.successorJobStoreIDToPredecessorJobs[jobGraph.jobStoreID]:
-
                     # Mark the predecessor as failed
                     self.toilState.hasFailedSuccessors.add(predecessorJobGraph.jobStoreID)
                     logger.debug("Totally failed job: %s is marking direct predecessor: %s "
@@ -877,15 +896,15 @@ class Leader(object):
             # Is a service job
             predecessorJob = self.toilState.serviceJobStoreIDToPredecessorJob.pop(jobStoreID)
             self.toilState.servicesIssued[predecessorJob.jobStoreID].pop(jobStoreID)
-            if len(self.toilState.servicesIssued[predecessorJob.jobStoreID]) == 0: # Predecessor job has
+            if len(self.toilState.servicesIssued[predecessorJob.jobStoreID]) == 0:  # Predecessor job has
                 # all its services terminated
-                self.toilState.servicesIssued.pop(predecessorJob.jobStoreID) # The job has no running services
-                self.toilState.updatedJobs.add((predecessorJob, 0)) # Now we know
+                self.toilState.servicesIssued.pop(predecessorJob.jobStoreID)  # The job has no running services
+                self.toilState.updatedJobs.add((predecessorJob, 0))  # Now we know
                 # the job is done we can add it to the list of updated job files
                 logger.debug("Job %s services have completed or totally failed, adding to updated jobs", predecessorJob)
 
         elif jobStoreID not in self.toilState.successorJobStoreIDToPredecessorJobs:
-            #We have reach the root job
+            # We have reach the root job
             assert len(self.toilState.updatedJobs) == 0
             assert len(self.toilState.successorJobStoreIDToPredecessorJobs) == 0
             assert len(self.toilState.successorCounts) == 0

--- a/src/toil/lib/bioio.py
+++ b/src/toil/lib/bioio.py
@@ -48,7 +48,10 @@ def getLogLevelString(logger=None):
         logger = rootLogger
     return logging.getLevelName(logger.getEffectiveLevel())
 
+
 __loggingFiles = []
+
+
 def addLoggingFileHandler(fileName, rotatingLogging=False):
     if fileName in __loggingFiles:
         return
@@ -77,7 +80,8 @@ def setLogLevel(level, logger=None):
     # There are quite a few cases where we expect AWS requests to fail, but it seems
     # that boto handles these by logging the error *and* raising an exception. We
     # don't want to confuse the user with those error messages.
-    logging.getLogger( 'boto' ).setLevel( logging.CRITICAL )
+    logging.getLogger('boto').setLevel(logging.CRITICAL)
+
 
 def logFile(fileName, printFunction=logger.info):
     """Writes out a formatted version of the given log file
@@ -92,7 +96,8 @@ def logFile(fileName, printFunction=logger.info):
         printFunction("%s:\t%s" % (shortName, line))
         line = fileHandle.readline()
     fileHandle.close()
-    
+
+
 def logStream(fileHandle, shortName, printFunction=logger.info):
     """Writes out a formatted version of the given log stream.
     """
@@ -104,6 +109,7 @@ def logStream(fileHandle, shortName, printFunction=logger.info):
         printFunction("%s:\t%s" % (shortName, line))
         line = fileHandle.readline()
     fileHandle.close()
+
 
 def addLoggingOptions(parser):
     # Wrapper function that allows toil to be used with both the optparse and
@@ -117,7 +123,9 @@ def addLoggingOptions(parser):
                            "addLoggingOptions(), %s. Expecting "
                            "argparse.ArgumentParser" % parser.__class__)
 
+
 supportedLogLevels = (logging.CRITICAL, logging.ERROR, logging.WARNING, logging.INFO, logging.DEBUG)
+
 
 def _addLoggingOptions(addOptionFn):
     """
@@ -125,7 +133,7 @@ def _addLoggingOptions(addOptionFn):
     """
     # BEFORE YOU ADD OR REMOVE OPTIONS TO THIS FUNCTION, KNOW THAT YOU MAY ONLY USE VARIABLES ACCEPTED BY BOTH
     # optparse AND argparse FOR EXAMPLE, YOU MAY NOT USE default=%default OR default=%(default)s
-    defaultLogLevelName = logging.getLevelName( defaultLogLevel )
+    defaultLogLevelName = logging.getLevelName(defaultLogLevel)
     addOptionFn("--logOff", dest="logLevel",
                 default=defaultLogLevelName,
                 action="store_const", const="CRITICAL",
@@ -143,6 +151,7 @@ def _addLoggingOptions(addOptionFn):
     addOptionFn("--logFile", dest="logFile", help="File to log in")
     addOptionFn("--rotatingLogging", dest="logRotating", action="store_true", default=False,
                 help="Turn on rotating logging, which prevents log files getting too big.")
+
 
 def setLoggingFromOptions(options):
     """
@@ -175,6 +184,7 @@ def system(command):
     logger.debug('Running: %r', command)
     subprocess.check_call(command, shell=isinstance(command, string_types), bufsize=-1)
 
+
 def getTotalCpuTimeAndMemoryUsage():
     """
     Gives the total cpu time of itself and all its children, and the maximum RSS memory usage of
@@ -186,15 +196,18 @@ def getTotalCpuTimeAndMemoryUsage():
     totalMemoryUsage = me.ru_maxrss + childs.ru_maxrss
     return totalCPUTime, totalMemoryUsage
 
+
 def getTotalCpuTime():
     """Gives the total cpu time, including the children.
     """
     return getTotalCpuTimeAndMemoryUsage()[0]
 
+
 def getTotalMemoryUsage():
     """Gets the amount of memory used by the process and its largest child.
     """
     return getTotalCpuTimeAndMemoryUsage()[1]
+
 
 def absSymPath(path):
     """like os.path.abspath except it doesn't dereference symlinks
@@ -202,10 +215,11 @@ def absSymPath(path):
     curr_path = os.getcwd()
     return os.path.normpath(os.path.join(curr_path, path))
 
+
 #########################################################
 #########################################################
 #########################################################
-#testing settings
+# testing settings
 #########################################################
 #########################################################
 #########################################################
@@ -223,17 +237,21 @@ class TestStatus(object):
 
     def getTestStatus():
         return TestStatus.TEST_STATUS
+
     getTestStatus = staticmethod(getTestStatus)
 
     def setTestStatus(status):
-        assert status in (TestStatus.TEST_SHORT, TestStatus.TEST_MEDIUM, TestStatus.TEST_LONG, TestStatus.TEST_VERY_LONG)
+        assert status in (
+        TestStatus.TEST_SHORT, TestStatus.TEST_MEDIUM, TestStatus.TEST_LONG, TestStatus.TEST_VERY_LONG)
         TestStatus.TEST_STATUS = status
+
     setTestStatus = staticmethod(setTestStatus)
 
     def getSaveErrorLocation():
         """Location to in which to write inputs which created test error.
         """
         return TestStatus.SAVE_ERROR_LOCATION
+
     getSaveErrorLocation = staticmethod(getSaveErrorLocation)
 
     def setSaveErrorLocation(dir):
@@ -242,6 +260,7 @@ class TestStatus(object):
         logger.info("Location to save error files in: %s" % dir)
         assert os.path.isdir(dir)
         TestStatus.SAVE_ERROR_LOCATION = dir
+
     setSaveErrorLocation = staticmethod(setSaveErrorLocation)
 
     def getTestSetup(shortTestNo=1, mediumTestNo=5, longTestNo=100, veryLongTestNo=0):
@@ -251,8 +270,9 @@ class TestStatus(object):
             return mediumTestNo
         elif TestStatus.TEST_STATUS == TestStatus.TEST_LONG:
             return longTestNo
-        else: #Used for long example tests
+        else:  # Used for long example tests
             return veryLongTestNo
+
     getTestSetup = staticmethod(getTestSetup)
 
     def getPathToDataSets():
@@ -262,19 +282,22 @@ class TestStatus(object):
         """
         assert "SON_TRACE_DATASETS" in os.environ
         return os.environ["SON_TRACE_DATASETS"]
+
     getPathToDataSets = staticmethod(getPathToDataSets)
 
-def getBasicOptionParser( parser=None):
+
+def getBasicOptionParser(parser=None):
     if parser is None:
         parser = ArgumentParser()
 
     addLoggingOptions(parser)
 
     parser.add_argument("--tempDirRoot", dest="tempDirRoot", type=str,
-                      help="Path to where temporary directory containing all temp files are created, by default uses the current working directory as the base.",
-                      default=tempfile.gettempdir())
+                        help="Path to where temporary directory containing all temp files are created, by default uses the current working directory as the base.",
+                        default=tempfile.gettempdir())
 
     return parser
+
 
 def parseBasicOptions(parser):
     """Setups the standard things from things added by getBasicOptionParser.
@@ -283,16 +306,19 @@ def parseBasicOptions(parser):
 
     setLoggingFromOptions(options)
 
-    #Set up the temp dir root
-    if options.tempDirRoot == "None": # FIXME: Really, a string containing the word None?
+    # Set up the temp dir root
+    if options.tempDirRoot == "None":  # FIXME: Really, a string containing the word None?
         options.tempDirRoot = tempfile.gettempdir()
 
     return options
 
+
 def getRandomAlphaNumericString(length=10):
     """Returns a random alpha numeric string of the given length.
     """
-    return "".join([ random.choice('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz') for i in range(0, length) ])
+    return "".join(
+        [random.choice('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz') for i in range(0, length)])
+
 
 def makePublicDir(dirName):
     """Makes a given subdirectory if it doesn't already exist, making sure it is public.
@@ -301,6 +327,7 @@ def makePublicDir(dirName):
         os.mkdir(dirName)
         os.chmod(dirName, 0o777)
     return dirName
+
 
 def getTempFile(suffix="", rootDir=None):
     """Returns a string representing a temporary file, that must be manually deleted
@@ -312,5 +339,5 @@ def getTempFile(suffix="", rootDir=None):
     else:
         tmpFile = os.path.join(rootDir, "tmp_" + getRandomAlphaNumericString() + suffix)
         open(tmpFile, 'w').close()
-        os.chmod(tmpFile, 0o777) #Ensure everyone has access to the file.
+        os.chmod(tmpFile, 0o777)  # Ensure everyone has access to the file.
         return tmpFile

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -42,6 +42,7 @@ def dockerCheckOutput(job, *args, **kwargs):
                 "is deprecated, please switch to apiDockerCall().")
     return subprocessDockerCall(job=job, *args, **kwargs)
 
+
 def dockerCall(job, *args, **kwargs):
     """
     Deprecated.  Runs subprocessDockerCall() using 'subprocess.check_output()'.
@@ -53,6 +54,7 @@ def dockerCall(job, *args, **kwargs):
     logger.warn("WARNING: dockerCall() using subprocess.check_output() "
                 "is deprecated, please switch to apiDockerCall().")
     return subprocessDockerCall(job=job, *args, **kwargs)
+
 
 def subprocessDockerCall(job,
                          tool,
@@ -161,9 +163,9 @@ def subprocessDockerCall(job,
                                               for q in parameters]]
         # Use bash's set -eo pipefail to detect and abort on a failure in any
         # command in the chain
-        call = baseDockerCall + ['--entrypoint', '/bin/bash',  tool, '-c',
+        call = baseDockerCall + ['--entrypoint', '/bin/bash', tool, '-c',
                                  'set -eo pipefail && {}'.format(' | '
-                                                         .join(chain_params))]
+                                                                 .join(chain_params))]
     else:
         call = baseDockerCall + [tool] + parameters
     logger.info("Calling docker with " + repr(call))
@@ -178,6 +180,7 @@ def subprocessDockerCall(job,
 
     _fixPermissions(tool=tool, workDir=workDir)
     return out
+
 
 def apiDockerCall(job,
                   image,
@@ -282,7 +285,7 @@ def apiDockerCall(job,
         if entrypoint is None:
             entrypoint = ['/bin/bash', '-c']
         chain_params = \
-            [' '.join((pipes.quote(arg) for arg in command)) \
+            [' '.join((pipes.quote(arg) for arg in command))
              for command in parameters]
         command = ' | '.join(chain_params)
         pipe_prefix = "set -eo pipefail && "
@@ -345,7 +348,7 @@ def apiDockerCall(job,
     # If the container exits with a non-zero exit code and detach is False.
     except ContainerError:
         logger.error("Docker had non-zero exit.  Check your command: " + \
-                      repr(command))
+                     repr(command))
         raise
     except ImageNotFound:
         logger.error("Docker image not found.")
@@ -355,6 +358,7 @@ def apiDockerCall(job,
         raise create_api_error_from_http_exception(e)
     except:
         raise
+
 
 def dockerKill(container_name, client, gentleKill=False):
     """
@@ -373,11 +377,12 @@ def dockerKill(container_name, client, gentleKill=False):
             this_container = client.containers.get(container_name)
     except NotFound:
         logger.debug("Attempted to stop container, but container != exist: ",
-                      container_name)
+                     container_name)
     except requests.exceptions.HTTPError as e:
         logger.debug("Attempted to stop container, but server gave an error: ",
-                      container_name)
+                     container_name)
         raise create_api_error_from_http_exception(e)
+
 
 def dockerStop(container_name, client):
     """
@@ -387,6 +392,7 @@ def dockerStop(container_name, client):
     :param client: The docker API client object to call.
     """
     dockerKill(container_name, client, gentleKill=True)
+
 
 def containerIsRunning(container_name):
     """
@@ -407,14 +413,15 @@ def containerIsRunning(container_name):
         return None
     except requests.exceptions.HTTPError as e:
         logger.debug("Server error attempting to call container: ",
-                      container_name)
+                     container_name)
         raise create_api_error_from_http_exception(e)
+
 
 def getContainerName(job):
     """Create a random string including the job name, and return it."""
     return '--'.join([str(job),
-                      base64.b64encode(os.urandom(9), '-_')])\
-                      .replace("'", '').replace('"', '').replace('_', '')
+                      base64.b64encode(os.urandom(9), '-_')]) \
+        .replace("'", '').replace('"', '').replace('_', '')
 
 
 def _dockerKill(containerName, action):
@@ -429,16 +436,16 @@ def _dockerKill(containerName, action):
         # container was run with --rm and has already exited before this call.
         logger.info('The container with name "%s" appears to have already been '
                     'removed.  Nothing to '
-                  'do.', containerName)
+                    'do.', containerName)
     else:
         if action in (None, FORGO):
             logger.info('The container with name %s continues to exist as we '
                         'were asked to forgo a '
-                      'post-job action on it.', containerName)
+                        'post-job action on it.', containerName)
         else:
             logger.info('The container with name %s exists. Running '
                         'user-specified defer functions.',
-                         containerName)
+                        containerName)
             if running and action >= STOP:
                 logger.info('Stopping container "%s".', containerName)
                 for attempt in retry(predicate=dockerPredicate):
@@ -461,7 +468,8 @@ def _dockerKill(containerName, action):
                 else:
                     logger.info('Container "%s" was not found on the system.'
                                 'Nothing to remove.',
-                                 containerName)
+                                containerName)
+
 
 def _fixPermissions(tool, workDir):
     """

--- a/src/toil/lib/ec2.py
+++ b/src/toil/lib/ec2.py
@@ -37,7 +37,7 @@ def not_found(e):
 def retry_ec2(
         retry_after=a_short_time,
         retry_for=10 *
-        a_short_time,
+                  a_short_time,
         retry_while=not_found):
     t = retry_after
     return retry(
@@ -416,6 +416,7 @@ def create_spot_instances(
     """
     :rtype: Iterator[list[Instance]]
     """
+
     def spotRequestNotFound(e):
         return e.error_code == "InvalidSpotInstanceRequestID.NotFound"
 

--- a/src/toil/lib/encryption/_nacl.py
+++ b/src/toil/lib/encryption/_nacl.py
@@ -16,9 +16,9 @@ from builtins import str
 import nacl
 from nacl.secret import SecretBox
 
-
 # 16-byte MAC plus a nonce is added to every message.
 overhead = 16 + SecretBox.NONCE_SIZE
+
 
 def encrypt(message, keyPath):
     """
@@ -54,6 +54,7 @@ def encrypt(message, keyPath):
     nonce = nacl.utils.random(SecretBox.NONCE_SIZE)
     assert len(nonce) == SecretBox.NONCE_SIZE
     return bytes(sb.encrypt(message, nonce))
+
 
 def decrypt(ciphertext, keyPath):
     """

--- a/src/toil/provisioners/abstractProvisioner.py
+++ b/src/toil/provisioners/abstractProvisioner.py
@@ -17,14 +17,10 @@ from abc import ABCMeta, abstractmethod
 
 from collections import namedtuple
 
-
-
 from bd2k.util.retry import never
 from future.utils import with_metaclass
 
-
 log = logging.getLogger(__name__)
-
 
 Shape = namedtuple("_Shape", "wallTime memory cores disk preemptable")
 """
@@ -44,7 +40,6 @@ class AbstractProvisioner(with_metaclass(ABCMeta, object)):
     An abstract base class to represent the interface for provisioning worker nodes to use in a
     Toil cluster.
     """
-
 
     def __init__(self, config=None):
         """
@@ -85,7 +80,7 @@ class AbstractProvisioner(with_metaclass(ABCMeta, object)):
         prefix = 'non-' if not preemptable else ''
         log.debug("Adding %s to %spreemptable static nodes", nodes, prefix)
         if nodes is not None:
-            self.static[preemptable] = {node.privateIP : node for node in nodes}
+            self.static[preemptable] = {node.privateIP: node for node in nodes}
 
     @abstractmethod
     def addNodes(self, nodeType, numNodes, preemptable):

--- a/src/toil/provisioners/aws/__init__.py
+++ b/src/toil/provisioners/aws/__init__.py
@@ -167,7 +167,8 @@ def _check_spot_bid(spot_bid, spot_history):
     average = mean([datum.price for datum in spot_history])
     if spot_bid > average * 2:
         logger.warn("Your bid $ %f is more than double this instance type's average "
-                 "spot price ($ %f) over the last week", spot_bid, average)
+                    "spot price ($ %f) over the last week", spot_bid, average)
+
 
 def _get_spot_history(ctx, instance_type):
     """
@@ -184,6 +185,7 @@ def _get_spot_history(ctx, instance_type):
     spot_data.sort(key=attrgetter("timestamp"), reverse=True)
     return spot_data
 
+
 ec2FullPolicy = dict(Version="2012-10-17", Statement=[
     dict(Effect="Allow", Resource="*", Action="ec2:*")])
 
@@ -195,7 +197,6 @@ sdbFullPolicy = dict(Version="2012-10-17", Statement=[
 
 iamFullPolicy = dict(Version="2012-10-17", Statement=[
     dict(Effect="Allow", Resource="*", Action="iam:*")])
-
 
 logDir = '--log_dir=/var/lib/mesos'
 leaderArgs = logDir + ' --registry=in_memory --cluster={name}'

--- a/src/toil/realtimeLogger.py
+++ b/src/toil/realtimeLogger.py
@@ -18,6 +18,7 @@ Implements a real-time UDP-based logging system that user scripts can use for de
 
 from __future__ import absolute_import
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import object
 import os
@@ -137,8 +138,8 @@ class RealtimeLogger(with_metaclass(RealtimeLoggerMetaclass, object)):
                     log.info('Starting real-time logging.')
                     # Start up the logging server
                     cls.loggingServer = SocketServer.ThreadingUDPServer(
-                            server_address=('0.0.0.0', 0),
-                            RequestHandlerClass=LoggingDatagramHandler)
+                        server_address=('0.0.0.0', 0),
+                        RequestHandlerClass=LoggingDatagramHandler)
 
                     # Set up a thread to do all the serving in the background and exit when we do
                     cls.serverThread = threading.Thread(target=cls.loggingServer.serve_forever)

--- a/src/toil/resource.py
+++ b/src/toil/resource.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import map
 import errno
@@ -312,6 +313,7 @@ class VirtualEnvResource(DirectoryResource):
     A resource read from a virtualenv on the leader. All modules and packages found in the
     virtualenv's site-packages directory will be included.
     """
+
     @classmethod
     def _load(cls, path):
         """

--- a/src/toil/statsAndLogging.py
+++ b/src/toil/statsAndLogging.py
@@ -26,10 +26,10 @@ from threading import Thread, Event
 from bd2k.util.expando import Expando
 from toil.lib.bioio import getTotalCpuTime
 
-logger = logging.getLogger( __name__ )
+logger = logging.getLogger(__name__)
 
 
-class StatsAndLogging( object ):
+class StatsAndLogging(object):
     """
     Class manages a thread that aggregates statistics and logging information on a toil run.
     """

--- a/src/toil/test/__init__.py
+++ b/src/toil/test/__init__.py
@@ -368,6 +368,7 @@ def needs_gridengine(test_item):
     else:
         return unittest.skip("Install GridEngine to include this test.")(test_item)
 
+
 def needs_torque(test_item):
     """
     Use as a decorator before test classes or methods to only run them if PBS/Torque is installed.
@@ -512,6 +513,7 @@ def integrative(test_item):
             'Set TOIL_TEST_INTEGRATIVE="True" to include this integration test, '
             'or run `make integration_test_local` to run all integration tests.')(test_item)
 
+
 def slow(test_item):
     """
     Use this decorator to identify tests that are slow and not critical.
@@ -523,6 +525,7 @@ def slow(test_item):
     else:
         return unittest.skip(
             'Skipped because TOIL_TEST_QUICK is "True"')(test_item)
+
 
 methodNamePartRegex = re.compile('^[a-zA-Z_0-9]+$')
 
@@ -611,6 +614,7 @@ def make_tests(generalMethod, targetClass, **kwargs):
     False
 
     """
+
     def pop(d):
         """
         Pops an arbitrary key value pair from a given dict.

--- a/src/toil/test/batchSystems/batchSystemTest.py
+++ b/src/toil/test/batchSystems/batchSystemTest.py
@@ -326,6 +326,7 @@ class hidden(object):
             self.assertTrue(locator.startswith('file:'))
             self.assertEqual(locator[len('file:'):], filePath)
 
+
 @slow
 @needs_mesos
 class MesosBatchSystemTest(hidden.AbstractBatchSystemTest, MesosTestSupport):
@@ -358,16 +359,15 @@ class MesosBatchSystemTest(hidden.AbstractBatchSystemTest, MesosTestSupport):
     def testIgnoreNode(self):
         self.batchSystem.ignoreNode('localhost')
         jobNode = JobNode(command='sleep 1000', jobName='test2', unitName=None,
-                           jobStoreID='1', requirements=defaultRequirements)
+                          jobStoreID='1', requirements=defaultRequirements)
         job = self.batchSystem.issueBatchJob(jobNode)
 
         issuedID = self._waitForJobsToIssue(1)
         self.assertEqual(set(issuedID), {job})
 
         runningJobIDs = self._waitForJobsToStart(1)
-        #Make sure job is NOT running
+        # Make sure job is NOT running
         self.assertEqual(set(runningJobIDs), set({}))
-
 
 
 class SingleMachineBatchSystemTest(hidden.AbstractBatchSystemTest):
@@ -381,6 +381,7 @@ class SingleMachineBatchSystemTest(hidden.AbstractBatchSystemTest):
     def createBatchSystem(self):
         return SingleMachineBatchSystem(config=self.config,
                                         maxCores=numCores, maxMemory=1e9, maxDisk=2001)
+
 
 @slow
 class MaxCoresSingleMachineBatchSystemTest(ToilTest):
@@ -481,7 +482,7 @@ class MaxCoresSingleMachineBatchSystemTest(ToilTest):
                             for i in range(0, int(jobs)):
                                 jobIds.add(bs.issueBatchJob(JobNode(command=self.scriptCommand(),
                                                                     requirements=dict(
-                                                                        cores=float( coresPerJob),
+                                                                        cores=float(coresPerJob),
                                                                         memory=1, disk=1,
                                                                         preemptable=preemptable),
                                                                     jobName=str(i), unitName='', jobStoreID=str(i))))
@@ -504,7 +505,6 @@ class MaxCoresSingleMachineBatchSystemTest(ToilTest):
                         expectedMaxConcurrentTasks = min(old_div(maxCores, coresPerJob), jobs)
                         self.assertEquals(maxConcurrentTasks, expectedMaxConcurrentTasks)
                         resetCounters(self.counterPath)
-
 
     @skipIf(SingleMachineBatchSystem.numCores < 3, 'Need at least three cores to run this test')
     def testServices(self):
@@ -555,6 +555,7 @@ class Service(Job.Service):
     def stop(self, fileStore):
         subprocess.check_call(self.cmd + ' -1', shell=True)
 
+
 @slow
 @needs_parasol
 class ParasolBatchSystemTest(hidden.AbstractBatchSystemTest, ParasolTestSupport):
@@ -574,7 +575,7 @@ class ParasolBatchSystemTest(hidden.AbstractBatchSystemTest, ParasolTestSupport)
     def createBatchSystem(self):
         memory = int(3e9)
         self._startParasol(numCores=numCores, memory=memory)
-        
+
         return ParasolBatchSystem(config=self.config,
                                   maxCores=numCores,
                                   maxMemory=memory,
@@ -651,6 +652,7 @@ class GridEngineBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
         for f in glob('toil_job*.o*'):
             os.unlink(f)
 
+
 @slow
 @needs_slurm
 class SlurmBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
@@ -670,6 +672,7 @@ class SlurmBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
         for f in glob('slurm-*.out'):
             os.unlink(f)
 
+
 @slow
 @needs_torque
 class TorqueBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
@@ -686,7 +689,7 @@ class TorqueBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
     def createBatchSystem(self):
         from toil.batchSystems.torque import TorqueBatchSystem
         return TorqueBatchSystem(config=self.config, maxCores=numCores, maxMemory=1000e9,
-                                     maxDisk=1e9)
+                                 maxDisk=1e9)
 
     def tearDown(self):
         super(TorqueBatchSystemTest, self).tearDown()
@@ -694,6 +697,7 @@ class TorqueBatchSystemTest(hidden.AbstractGridEngineBatchSystemTest):
         from glob import glob
         for f in glob('toil_job_*.[oe]*'):
             os.unlink(f)
+
 
 class SingleMachineBatchSystemJobTest(hidden.AbstractBatchSystemJobTest):
     """
@@ -725,7 +729,7 @@ class SingleMachineBatchSystemJobTest(hidden.AbstractBatchSystemJobTest):
         # Physically, we're asking for 50% of disk and 50% of disk + 500bytes in the two jobs. The
         # batchsystem should not allow the 2 child jobs to run concurrently.
         root.addChild(Job.wrapFn(measureConcurrency, counterPath, self.sleepTime, cores=1,
-                                    memory='1M', disk=old_div(availableDisk,2)))
+                                 memory='1M', disk=old_div(availableDisk, 2)))
         root.addChild(Job.wrapFn(measureConcurrency, counterPath, self.sleepTime, cores=1,
                                  memory='1M', disk=(old_div(availableDisk, 2)) + 500))
         Job.Runner.startToil(root, options)
@@ -763,15 +767,15 @@ class SingleMachineBatchSystemJobTest(hidden.AbstractBatchSystemJobTest):
 
         # Should block off 50% of memory while waiting for it's 3 cores
         firstJobChild = Job.wrapFn(_resourceBlockTestAuxFn, outFile=outFile, sleepTime=0,
-                                   writeVal='fJC', cores=3, memory=int(old_div(availableMemory,2)), disk='1M')
+                                   writeVal='fJC', cores=3, memory=int(old_div(availableMemory, 2)), disk='1M')
 
         # These two shouldn't be able to run before B because there should be only
         # (50% of memory - 1M) available (firstJobChild should be blocking 50%)
         secondJobChild = Job.wrapFn(_resourceBlockTestAuxFn, outFile=outFile, sleepTime=5,
-                                    writeVal='sJC', cores=2, memory=int(old_div(availableMemory,1.5)),
+                                    writeVal='sJC', cores=2, memory=int(old_div(availableMemory, 1.5)),
                                     disk='1M')
         secondJobGrandChild = Job.wrapFn(_resourceBlockTestAuxFn, outFile=outFile, sleepTime=5,
-                                         writeVal='sJGC', cores=2, memory=int(old_div(availableMemory,1.5)),
+                                         writeVal='sJGC', cores=2, memory=int(old_div(availableMemory, 1.5)),
                                          disk='1M')
 
         root.addChild(blocker)

--- a/src/toil/test/cwl/cwlTest.py
+++ b/src/toil/test/cwl/cwlTest.py
@@ -30,14 +30,13 @@ from toil.test import ToilTest, needs_cwl, slow
 
 @needs_cwl
 class CWLTest(ToilTest):
-
     def _tester(self, cwlfile, jobfile, outDir, expect):
         from toil.cwl import cwltoil
         rootDir = self._projectRootPath()
         st = StringIO()
         cwltoil.main(['--outdir', outDir,
-                            os.path.join(rootDir, cwlfile),
-                            os.path.join(rootDir, jobfile)],
+                      os.path.join(rootDir, cwlfile),
+                      os.path.join(rootDir, jobfile)],
                      stdout=st)
         out = json.loads(st.getvalue())
         out["output"].pop("http://commonwl.org/cwltool#generation", None)
@@ -50,8 +49,8 @@ class CWLTest(ToilTest):
         rootDir = self._projectRootPath()
         st = StringIO()
         cwltoil.main(['--debug-worker', '--outdir', outDir,
-                     os.path.join(rootDir, cwlfile),
-                     os.path.join(rootDir, jobfile)], stdout=st)
+                      os.path.join(rootDir, cwlfile),
+                      os.path.join(rootDir, jobfile)], stdout=st)
         out = json.loads(st.getvalue())
         out["output"].pop("http://commonwl.org/cwltool#generation", None)
         out["output"].pop("nameext", None)
@@ -63,29 +62,29 @@ class CWLTest(ToilTest):
         self._tester('src/toil/test/cwl/revsort.cwl',
                      'src/toil/test/cwl/revsort-job.json',
                      outDir, {
-            # Having unicode string literals isn't necessary for the assertion but makes for a
-            # less noisy diff in case the assertion fails.
-            u'output': {
-                u'location': "file://" + str(os.path.join(outDir, 'output.txt')),
-                u'basename': str("output.txt"),
-                u'size': 1111,
-                u'class': u'File',
-                u'checksum': u'sha1$b9214658cc453331b62c2282b772a5c063dbd284'}})
+                         # Having unicode string literals isn't necessary for the assertion but makes for a
+                         # less noisy diff in case the assertion fails.
+                         u'output': {
+                             u'location': "file://" + str(os.path.join(outDir, 'output.txt')),
+                             u'basename': str("output.txt"),
+                             u'size': 1111,
+                             u'class': u'File',
+                             u'checksum': u'sha1$b9214658cc453331b62c2282b772a5c063dbd284'}})
 
     def test_run_revsort_debug_worker(self):
         outDir = self._createTempDir()
         # Having unicode string literals isn't necessary for the assertion
         # but makes for a less noisy diff in case the assertion fails.
         self._debug_worker_tester(
-                'src/toil/test/cwl/revsort.cwl',
-                'src/toil/test/cwl/revsort-job.json', outDir, {u'output': {
-                    u'location': "file://" + str(os.path.join(
-                        outDir, 'output.txt')),
-                    u'basename': str("output.txt"),
-                    u'size': 1111,
-                    u'class': u'File',
-                    u'checksum':
-                        u'sha1$b9214658cc453331b62c2282b772a5c063dbd284'}})
+            'src/toil/test/cwl/revsort.cwl',
+            'src/toil/test/cwl/revsort-job.json', outDir, {u'output': {
+                u'location': "file://" + str(os.path.join(
+                    outDir, 'output.txt')),
+                u'basename': str("output.txt"),
+                u'size': 1111,
+                u'class': u'File',
+                u'checksum':
+                    u'sha1$b9214658cc453331b62c2282b772a5c063dbd284'}})
 
     @slow
     def test_restart(self):
@@ -102,6 +101,7 @@ class CWLTest(ToilTest):
         def path_without_rev():
             return ":".join([d for d in os.environ["PATH"].split(":")
                              if not os.path.exists(os.path.join(d, "rev"))])
+
         orig_path = os.environ["PATH"]
         # Force a failure and half finished job by removing `rev` from the PATH
         os.environ["PATH"] = path_without_rev()

--- a/src/toil/test/jobStores/jobStoreTest.py
+++ b/src/toil/test/jobStores/jobStoreTest.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 from __future__ import division
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import next
 from builtins import str
@@ -160,9 +161,6 @@ class AbstractJobStoreTest(object):
             self.assertEquals(jobOnMaster.predecessorNumber, 0)
             self.assertEquals(jobOnMaster.predecessorsFinished, set())
             self.assertEquals(jobOnMaster.logJobStoreFileID, None)
-
-            
-
 
             # Create a second instance of the job store, simulating a worker ...
             #
@@ -376,9 +374,9 @@ class AbstractJobStoreTest(object):
             with master.batch():
                 for i in range(100):
                     overlargeJobNodeOnMaster = JobNode(command='master-overlarge',
-                                        requirements=masterRequirements,
-                                        jobName='test-overlarge', unitName='onMaster',
-                                        jobStoreID=None, predecessorNumber=0)
+                                                       requirements=masterRequirements,
+                                                       jobName='test-overlarge', unitName='onMaster',
+                                                       jobStoreID=None, predecessorNumber=0)
                     jobGraphs.append(master.create(overlargeJobNodeOnMaster))
             for jobGraph in jobGraphs:
                 self.assertTrue(master.exists(jobGraph.jobStoreID))
@@ -522,7 +520,7 @@ class AbstractJobStoreTest(object):
                 http.server_close()
 
         def testImportFtpFile(self):
-            file = {'name':'foo', 'content':'foo bar baz qux'}
+            file = {'name': 'foo', 'content': 'foo bar baz qux'}
             ftp = FTPStubServer(0)
             ftp.run()
             try:
@@ -754,7 +752,7 @@ class AbstractJobStoreTest(object):
                 f.write('a' * 300000)
             with self.master.readFileStream(fileID) as f:
                 self.assertEquals(f.read(1), "a")
-            # If it times out here, there's a deadlock
+                # If it times out here, there's a deadlock
 
         @abstractmethod
         def _corruptJobStore(self):
@@ -933,13 +931,12 @@ class GoogleJobStoreTest(AbstractJobStoreTest.Test):
 
 @needs_aws
 class AWSJobStoreTest(AbstractJobStoreTest.Test):
-
     def _createJobStore(self):
         from toil.jobStores.aws.jobStore import AWSJobStore
         partSize = self._partSize()
         for encrypted in (True, False):
             self.assertTrue(AWSJobStore.FileInfo.maxInlinedSize(encrypted) < partSize)
-        return AWSJobStore(self.awsRegion()+ ':' + self.namePrefix, partSize=partSize)
+        return AWSJobStore(self.awsRegion() + ':' + self.namePrefix, partSize=partSize)
 
     def _corruptJobStore(self):
         from toil.jobStores.aws.jobStore import AWSJobStore
@@ -965,7 +962,7 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
             testJobStoreUUID = str(uuid.uuid4())
             # Create the nucket at the external region
             s3 = S3Connection()
-            for attempt in retry_s3(delays=(2,5,10,30,60), timeout=600):
+            for attempt in retry_s3(delays=(2, 5, 10, 30, 60), timeout=600):
                 with attempt:
                     bucket = s3.create_bucket('domain-test-' + testJobStoreUUID + '--files',
                                               location=externalAWSLocation)
@@ -1044,15 +1041,16 @@ class AWSJobStoreTest(AbstractJobStoreTest.Test):
                 self.assertEquals(e.message, 'Failed to copy at least %d part(s)' % (old_div(num_parts, 2)))
             else:
                 self.fail('Expected a RuntimeError to be raised')
+
     def testOverlargeJob(self):
         master = self.master
         masterRequirements = dict(memory=12, cores=34, disk=35, preemptable=True)
         overlargeJobNodeOnMaster = JobNode(command='master-overlarge',
-                                    requirements=masterRequirements,
-                                    jobName='test-overlarge', unitName='onMaster',
-                                    jobStoreID=None, predecessorNumber=0)
+                                           requirements=masterRequirements,
+                                           jobName='test-overlarge', unitName='onMaster',
+                                           jobStoreID=None, predecessorNumber=0)
 
-        #Make the pickled size of the job larger than 256K
+        # Make the pickled size of the job larger than 256K
         with open("/dev/urandom", "r") as random:
             overlargeJobNodeOnMaster.jobName = random.read(512 * 1024)
         overlargeJobOnMaster = master.create(overlargeJobNodeOnMaster)
@@ -1145,7 +1143,7 @@ class AzureJobStoreTest(AbstractJobStoreTest.Test):
         from toil.jobStores.azureJobStore import maxAzureTablePropertySize
         command = os.urandom(maxAzureTablePropertySize * 2)
         jobNode1 = self.arbitraryJob
-        jobNode1.command=command
+        jobNode1.command = command
         job1 = self.master.create(jobNode1)
         self.assertEqual(job1.command, command)
         job2 = self.master.load(job1.jobStoreID)
@@ -1235,6 +1233,7 @@ class EncryptedAzureJobStoreTest(AzureJobStoreTest, AbstractEncryptedJobStoreTes
 
 class StubHttpRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
     fileContents = 'A good programmer looks both ways before crossing a one-way street'
+
     def do_GET(self):
         self.send_response(200)
         self.send_header("Content-type", "text/plain")

--- a/src/toil/test/lib/dockerTest.py
+++ b/src/toil/test/lib/dockerTest.py
@@ -32,6 +32,7 @@ class DockerTest(ToilTest):
     removed during tear down.
     Otherwise, left-over files will not be removed.
     """
+
     def setUp(self):
         self.tempDir = self._createTempDir(purpose='tempDir')
         self.dockerTestLogLevel = 'INFO'
@@ -272,6 +273,7 @@ class DockerTest(ToilTest):
     def testNonCachingDockerChainErrorDetection(self):
         self.testDockerPipeChainErrorDetection(disableCaching=False)
 
+
 def _testDockerCleanFn(job,
                        working_dir,
                        detached=None,
@@ -288,6 +290,7 @@ def _testDockerCleanFn(job,
     :param int deferParam: See `deferParam=` in :func:`dockerCall`
     :param str containerName: See `container_name=` in :func:`dockerCall`
     """
+
     def killSelf():
         test_file = os.path.join(working_dir, 'test.txt')
         # Kill the worker once we are sure the docker container is started
@@ -311,17 +314,19 @@ def _testDockerCleanFn(job,
                   remove=rm,
                   privileged=True)
 
+
 def _testDockerPipeChainFn(job):
     """Return the result of a simple pipe chain.  Should be 2."""
-    parameters = [ ['printf', 'x\n y\n'], ['wc', '-l'] ]
+    parameters = [['printf', 'x\n y\n'], ['wc', '-l']]
     return apiDockerCall(job,
                          image='quay.io/ucsc_cgl/spooky_test',
                          parameters=parameters,
                          privileged=True)
 
+
 def _testDockerPipeChainErrorFn(job):
     """Return True if the command exit 1 | wc -l raises a ContainerError."""
-    parameters = [ ['exit', '1'], ['wc', '-l'] ]
+    parameters = [['exit', '1'], ['wc', '-l']]
     try:
         apiDockerCall(job,
                       image='quay.io/ucsc_cgl/spooky_test',

--- a/src/toil/test/mesos/helloWorld.py
+++ b/src/toil/test/mesos/helloWorld.py
@@ -24,8 +24,8 @@ from toil.job import Job
 childMessage = "The child job is now running!"
 parentMessage = "The parent job is now running!"
 
-def hello_world(job):
 
+def hello_world(job):
     job.fileStore.logToMaster(parentMessage)
     with open('foo_bam.txt', 'w') as handle:
         handle.write('\nThis is a triumph...\n')
@@ -33,13 +33,11 @@ def hello_world(job):
     # Assign FileStoreID to a given file
     foo_bam = job.fileStore.writeGlobalFile('foo_bam.txt')
 
-
     # Spawn child
     job.addChildJobFn(hello_world_child, foo_bam, memory=100, cores=0.5, disk="3G")
 
 
 def hello_world_child(job, hw):
-
     path = job.fileStore.readGlobalFile(hw)
     job.fileStore.logToMaster(childMessage)
     # NOTE: path and the udpated file are stored to /tmp

--- a/src/toil/test/mesos/stress.py
+++ b/src/toil/test/mesos/stress.py
@@ -19,58 +19,61 @@ from argparse import ArgumentParser
 
 from toil.job import Job
 
-def touchFile( fileStore ):
+
+def touchFile(fileStore):
     with fileStore.writeGlobalFileStream() as (f, id):
-        f.write( "This is a triumph" )
+        f.write("This is a triumph")
+
 
 class LongTestJob(Job):
     def __init__(self, numJobs):
-        Job.__init__(self,  memory=100000, cores=0.01)
+        Job.__init__(self, memory=100000, cores=0.01)
         self.numJobs = numJobs
 
     def run(self, fileStore):
-        for i in range(0,self.numJobs):
+        for i in range(0, self.numJobs):
             self.addChild(HelloWorldJob(i))
         self.addFollowOn(LongTestFollowOn())
 
-class LongTestFollowOn(Job):
 
+class LongTestFollowOn(Job):
     def __init__(self):
-        Job.__init__(self,  memory=1000000, cores=0.01)
+        Job.__init__(self, memory=1000000, cores=0.01)
 
     def run(self, fileStore):
-        touchFile( fileStore )
+        touchFile(fileStore)
+
 
 class HelloWorldJob(Job):
-
-    def __init__(self,i):
-        Job.__init__(self,  memory=100000, cores=0.01)
-        self.i=i
-
-
-    def run(self, fileStore):
-        touchFile( fileStore )
-        self.addFollowOn(HelloWorldFollowOn(self.i))
-
-class HelloWorldFollowOn(Job):
-
-    def __init__(self,i):
-        Job.__init__(self,  memory=200000, cores=0.01)
+    def __init__(self, i):
+        Job.__init__(self, memory=100000, cores=0.01)
         self.i = i
 
     def run(self, fileStore):
-        touchFile( fileStore)
+        touchFile(fileStore)
+        self.addFollowOn(HelloWorldFollowOn(self.i))
+
+
+class HelloWorldFollowOn(Job):
+    def __init__(self, i):
+        Job.__init__(self, memory=200000, cores=0.01)
+        self.i = i
+
+    def run(self, fileStore):
+        touchFile(fileStore)
+
 
 def main(numJobs):
     # Boilerplate -- startToil requires options
     parser = ArgumentParser()
     Job.Runner.addToilOptions(parser)
-    options = parser.parse_args( args=['./toilTest'] )
-    options.batchSystem="mesos"
-    options.mesosMasterAddress="localhost:5050"
+    options = parser.parse_args(args=['./toilTest'])
+    options.batchSystem = "mesos"
+    options.mesosMasterAddress = "localhost:5050"
     # Launch first toil Job
-    i = LongTestJob( numJobs )
-    Job.Runner.startToil(i,  options )
+    i = LongTestJob(numJobs)
+    Job.Runner.startToil(i, options)
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     main(numJobs=5)

--- a/src/toil/test/provisioners/aws/awsProvisionerTest.py
+++ b/src/toil/test/provisioners/aws/awsProvisionerTest.py
@@ -28,11 +28,9 @@ from boto.ec2.blockdevicemapping import BlockDeviceType
 from boto.exception import EC2ResponseError
 from toil.lib.ec2 import wait_instances_running
 
-
 from toil.provisioners.aws.awsProvisioner import AWSProvisioner
 
 from uuid import uuid4
-
 
 from toil.test import needs_aws, integrative, ToilTest, needs_appliance, timeLimit, slow
 
@@ -44,7 +42,6 @@ log = logging.getLogger(__name__)
 @needs_appliance
 @slow
 class AbstractAWSAutoscaleTest(ToilTest):
-
     def sshUtil(self, command):
         baseCommand = ['toil', 'ssh-cluster', '--insecure', '-p=aws', self.clusterName]
         callCommand = baseCommand + command
@@ -111,7 +108,6 @@ class AbstractAWSAutoscaleTest(ToilTest):
         """
         raise NotImplementedError()
 
-
     @abstractmethod
     def _runScript(self, toilOptions):
         """
@@ -171,7 +167,7 @@ class AbstractAWSAutoscaleTest(ToilTest):
         checkStatsCommand = ['/home/venv/bin/python', '-c',
                              'import json; import os; '
                              'json.load(open("/home/" + [f for f in os.listdir("/home/") '
-                                                   'if f.endswith(".json")].pop()))'
+                             'if f.endswith(".json")].pop()))'
                              ]
 
         self.sshUtil(checkStatsCommand)
@@ -200,7 +196,6 @@ class AbstractAWSAutoscaleTest(ToilTest):
 
 @pytest.mark.timeout(1200)
 class AWSAutoscaleTest(AbstractAWSAutoscaleTest):
-
     def __init__(self, name):
         super(AWSAutoscaleTest, self).__init__(name)
         self.clusterName = 'provisioner-test-' + str(uuid4())
@@ -220,7 +215,8 @@ class AWSAutoscaleTest(AbstractAWSAutoscaleTest):
         os.unlink(fileToSort)
 
     def _runScript(self, toilOptions):
-        runCommand = ['/home/venv/bin/python', '/home/sort.py', '--fileToSort=/home/sortFile', '--sseKey=/home/sortFile']
+        runCommand = ['/home/venv/bin/python', '/home/sort.py', '--fileToSort=/home/sortFile',
+                      '--sseKey=/home/sortFile']
         runCommand.extend(toilOptions)
         self.sshUtil(runCommand)
 
@@ -261,6 +257,7 @@ class AWSStaticAutoscaleTest(AWSAutoscaleTest):
     """
     Runs the tests on a statically provisioned cluster with autoscaling enabled.
     """
+
     def __init__(self, name):
         super(AWSStaticAutoscaleTest, self).__init__(name)
         self.requestedNodeStorage = 20
@@ -268,7 +265,8 @@ class AWSStaticAutoscaleTest(AWSAutoscaleTest):
     def launchCluster(self):
         from boto.ec2.blockdevicemapping import BlockDeviceType
         self.createClusterUtil(args=['--leaderStorage', str(self.requestedLeaderStorage),
-                                     '--nodeTypes', ",".join(self.instanceTypes), '-w', ",".join(self.numWorkers), '--nodeStorage', str(self.requestedLeaderStorage)])
+                                     '--nodeTypes', ",".join(self.instanceTypes), '-w', ",".join(self.numWorkers),
+                                     '--nodeStorage', str(self.requestedLeaderStorage)])
 
         ctx = AWSProvisioner._buildContext(self.clusterName)
         nodes = AWSProvisioner._getNodesInCluster(ctx, self.clusterName, both=True)
@@ -291,9 +289,9 @@ class AWSStaticAutoscaleTest(AWSAutoscaleTest):
         runCommand.extend(toilOptions)
         self.sshUtil(runCommand)
 
+
 @pytest.mark.timeout(1200)
 class AWSAutoscaleTestMultipleNodeTypes(AbstractAWSAutoscaleTest):
-
     def __init__(self, name):
         super(AWSAutoscaleTestMultipleNodeTypes, self).__init__(name)
         self.clusterName = 'provisioner-test-' + str(uuid4())
@@ -311,10 +309,11 @@ class AWSAutoscaleTestMultipleNodeTypes(AbstractAWSAutoscaleTest):
         os.unlink(sseKeyFile)
 
     def _runScript(self, toilOptions):
-        #Set memory requirements so that sort jobs can be run
+        # Set memory requirements so that sort jobs can be run
         # on small instances, but merge jobs must be run on large
         # instances
-        runCommand = ['/home/venv/bin/python', '/home/sort.py', '--fileToSort=/home/s3am/bin/asadmin', '--sortMemory=1.0G', '--mergeMemory=3.0G']
+        runCommand = ['/home/venv/bin/python', '/home/sort.py', '--fileToSort=/home/s3am/bin/asadmin',
+                      '--sortMemory=1.0G', '--mergeMemory=3.0G']
         runCommand.extend(toilOptions)
         runCommand.append('--sseKey=/home/keyFile')
         self.sshUtil(runCommand)
@@ -323,8 +322,9 @@ class AWSAutoscaleTestMultipleNodeTypes(AbstractAWSAutoscaleTest):
     @needs_aws
     def testAutoScale(self):
         self.instanceTypes = ["t2.small", "m3.large"]
-        self.numWorkers = ['2','1']
+        self.numWorkers = ['2', '1']
         self._test()
+
 
 @pytest.mark.timeout(1200)
 class AWSRestartTest(AbstractAWSAutoscaleTest):
@@ -386,17 +386,17 @@ class AWSRestartTest(AbstractAWSAutoscaleTest):
     def testAutoScaledCluster(self):
         self._test()
 
+
 @pytest.mark.timeout(1200)
 class PreemptableDeficitCompensationTest(AbstractAWSAutoscaleTest):
-
     def __init__(self, name):
         super(PreemptableDeficitCompensationTest, self).__init__(name)
         self.clusterName = 'deficit-test-' + str(uuid4())
 
     def setUp(self):
         super(PreemptableDeficitCompensationTest, self).setUp()
-        self.instanceTypes = ['m3.large:0.01', "m3.large"] # instance needs to be available on the spot market
-        self.numWorkers = ['1','1']
+        self.instanceTypes = ['m3.large:0.01', "m3.large"]  # instance needs to be available on the spot market
+        self.numWorkers = ['1', '1']
         self.jobStore = 'aws:%s:deficit-%s' % (self.awsRegion(), uuid4())
 
     def test(self):

--- a/src/toil/test/src/checkpointTest.py
+++ b/src/toil/test/src/checkpointTest.py
@@ -18,6 +18,7 @@ from toil.test import ToilTest, slow
 from toil.leader import FailedJobsException
 from toil.jobStores.abstractJobStore import NoSuchFileException
 
+
 class CheckpointTest(ToilTest):
     def testCheckpointNotRetried(self):
         """A checkpoint job should not be retried if the workflow has a retryCount of 0."""
@@ -63,8 +64,10 @@ class CheckpointTest(ToilTest):
         except FailedJobsException:
             self.fail("Checkpointed workflow restart doesn't clean failures.")
 
+
 class CheckRetryCount(Job):
     """Fail N times, succeed on the next try."""
+
     def __init__(self, numFailuresBeforeSuccess):
         super(CheckRetryCount, self).__init__(checkpoint=True)
         self.numFailuresBeforeSuccess = numFailuresBeforeSuccess
@@ -86,9 +89,11 @@ class CheckRetryCount(Job):
         if retryCount < self.numFailuresBeforeSuccess:
             self.addChild(AlwaysFail())
 
+
 class AlwaysFail(Job):
     def run(self, fileStore):
         raise RuntimeError(":(")
+
 
 class CheckpointFailsFirstTime(Job):
     def __init__(self):
@@ -97,8 +102,10 @@ class CheckpointFailsFirstTime(Job):
     def run(self, fileStore):
         self.addChild(FailOnce())
 
+
 class FailOnce(Job):
     """Fail the first time the workflow is run, but succeed thereafter."""
+
     def run(self, fileStore):
         if fileStore.jobStore.config.workflowAttemptNumber < 1:
             raise RuntimeError("first time around")

--- a/src/toil/test/src/fileStoreTest.py
+++ b/src/toil/test/src/fileStoreTest.py
@@ -52,6 +52,7 @@ class hidden(object):
     Hiding the abstract test classes from the Unittest loader so it can be inherited in different
     test suites for the different job stores.
     """
+
     class AbstractFileStoreTest(with_metaclass(ABCMeta, ToilTest)):
         """
         An abstract base class for testing the various general functions described in
@@ -752,6 +753,7 @@ class hidden(object):
             """
             # Make this take longer so we can test asynchronous writes across jobs/workers.
             oldHarbingerFileRead = job.fileStore.HarbingerFile.read
+
             def newHarbingerFileRead(self):
                 time.sleep(5)
                 return oldHarbingerFileRead(self)
@@ -965,7 +967,7 @@ class hidden(object):
         def _writeExportGlobalFile(job):
             fileName = os.path.join(job.fileStore.getLocalTempDir(), 'testfile')
             with open(fileName, 'wb') as f:
-                f.write(os.urandom(1024 * 30000)) # 30 Mb
+                f.write(os.urandom(1024 * 30000))  # 30 Mb
             outputFile = os.path.join(job.fileStore.getLocalTempDir(), 'exportedFile')
             job.fileStore.exportFile(job.fileStore.writeGlobalFile(fileName), 'File://' + outputFile)
             assert filecmp.cmp(fileName, outputFile)
@@ -1290,6 +1292,7 @@ class _deleteMethods(object):
 
 class NonCachingFileStoreTestWithFileJobStore(hidden.AbstractNonCachingFileStoreTest):
     jobStoreType = 'file'
+
 
 @pytest.mark.timeout(1000)
 class CachingFileStoreTestWithFileJobStore(hidden.AbstractCachingFileStoreTest):

--- a/src/toil/test/src/helloWorldTest.py
+++ b/src/toil/test/src/helloWorldTest.py
@@ -16,33 +16,37 @@ from __future__ import absolute_import
 from toil.job import Job
 from toil.test import ToilTest
 
+
 class HelloWorldTest(ToilTest):
     def testHelloWorld(self):
         options = Job.Runner.getDefaultOptions(self._getTestJobStorePath())
         options.logLevel = "INFO"
         Job.Runner.startToil(HelloWorld(), options)
 
+
 class HelloWorld(Job):
     def __init__(self):
-        Job.__init__(self,  memory=100000, cores=2, disk="3G")
+        Job.__init__(self, memory=100000, cores=2, disk="3G")
 
     def run(self, fileStore):
         fileID = self.addChildJobFn(childFn, cores=1, memory="1M", disk="3G").rv()
         self.addFollowOn(FollowOn(fileID))
+
 
 def childFn(job):
     with job.fileStore.writeGlobalFileStream() as (fH, fileID):
         fH.write("Hello, World!")
         return fileID
 
+
 class FollowOn(Job):
-    def __init__(self,fileId):
+    def __init__(self, fileId):
         Job.__init__(self)
-        self.fileId=fileId
+        self.fileId = fileId
 
     def run(self, fileStore):
         tempDir = fileStore.getLocalTempDir()
-        tempFilePath = "/".join([tempDir,"LocalCopy"])
+        tempFilePath = "/".join([tempDir, "LocalCopy"])
         with fileStore.readGlobalFileStream(self.fileId) as globalFile:
             with open(tempFilePath, "w") as localFile:
                 localFile.write(globalFile.read())

--- a/src/toil/test/src/hotDeploymentTest.py
+++ b/src/toil/test/src/hotDeploymentTest.py
@@ -461,7 +461,7 @@ class HotDeploymentTest(ApplianceTestSupport):
                             try:
                                 toil.start(Job.wrapJobFn(root))
                             except FailedJobsException as e:
-                                assert e.numberOfFailedJobs == 2 # `root` and `deferring`
+                                assert e.numberOfFailedJobs == 2  # `root` and `deferring`
                                 assert not os.path.exists(deferredFilePath), \
                                     'Apparently, the deferred function did not run.'
                             else:

--- a/src/toil/test/src/jobEncapsulationTest.py
+++ b/src/toil/test/src/jobEncapsulationTest.py
@@ -66,6 +66,7 @@ class JobEncapsulationTest(ToilTest):
 def noOp():
     pass
 
+
 def encapsulatedJobFn(job, string, outFile):
     a = job.addChildFn(f, string, outFile)
     b = a.addFollowOnFn(f, a.rv(), outFile)

--- a/src/toil/test/src/jobGraphTest.py
+++ b/src/toil/test/src/jobGraphTest.py
@@ -20,8 +20,8 @@ from toil.job import Job
 from toil.test import ToilTest
 from toil.jobGraph import JobGraph
 
+
 class JobGraphTest(ToilTest):
-    
     def setUp(self):
         super(JobGraphTest, self).setUp()
         self.jobStorePath = self._getTestJobStorePath()
@@ -29,33 +29,33 @@ class JobGraphTest(ToilTest):
         Job.Runner.addToilOptions(parser)
         options = parser.parse_args(args=[self.jobStorePath])
         self.toil = Toil(options)
-        self.assertEquals( self.toil, self.toil.__enter__() )
+        self.assertEquals(self.toil, self.toil.__enter__())
 
     def tearDown(self):
         self.toil.__exit__(None, None, None)
         self.toil._jobStore.destroy()
         self.assertFalse(os.path.exists(self.jobStorePath))
         super(JobGraphTest, self).tearDown()
-    
-    def testJob(self):       
+
+    def testJob(self):
         """
         Tests functions of a job.
-        """ 
-    
+        """
+
         command = "by your command"
-        memory = 2^32
-        disk = 2^32
+        memory = 2 ^ 32
+        disk = 2 ^ 32
         cores = 1
         preemptable = 1
         jobStoreID = 100
         remainingRetryCount = 5
         predecessorNumber = 0
-        
+
         j = JobGraph(command=command, memory=memory, cores=cores, disk=disk, preemptable=preemptable,
                      jobStoreID=jobStoreID, remainingRetryCount=remainingRetryCount,
                      predecessorNumber=predecessorNumber, jobName='testJobGraph', unitName='noName')
-        
-        #Check attributes
+
+        # Check attributes
         #
         self.assertEquals(j.command, command)
         self.assertEquals(j.memory, memory)
@@ -68,15 +68,15 @@ class JobGraphTest(ToilTest):
         self.assertEquals(j.stack, [])
         self.assertEquals(j.predecessorsFinished, set())
         self.assertEquals(j.logJobStoreFileID, None)
-        
-        #Check equals function
+
+        # Check equals function
         j2 = JobGraph(command=command, memory=memory, cores=cores, disk=disk,
                       preemptable=preemptable,
                       jobStoreID=jobStoreID, remainingRetryCount=remainingRetryCount,
                       predecessorNumber=predecessorNumber, jobName='testJobGraph', unitName='noName')
         self.assertEquals(j, j2)
-        #Change an attribute and check not equal
+        # Change an attribute and check not equal
         j.predecessorsFinished = {"1", "2"}
         self.assertNotEquals(j, j2)
-        
+
         ###TODO test other functionality

--- a/src/toil/test/src/jobTest.py
+++ b/src/toil/test/src/jobTest.py
@@ -34,6 +34,7 @@ from toil.test import ToilTest, slow
 
 logger = logging.getLogger(__name__)
 
+
 class JobTest(ToilTest):
     """
     Tests testing the job class
@@ -43,7 +44,6 @@ class JobTest(ToilTest):
     def setUpClass(cls):
         super(JobTest, cls).setUpClass()
         logging.basicConfig(level=logging.DEBUG)
-
 
     def testResourceRequirements(self):
         """
@@ -201,7 +201,7 @@ class JobTest(ToilTest):
             # Get an adjacency list representation and check is acyclic
             adjacencyList = self.getAdjacencyList(nodeNumber, childEdges)
             self.assertTrue(self.isAcyclic(adjacencyList))
-            
+
             # Add in follow-on edges - these are returned as a list, and as a set of augmented
             # edges in the adjacency list
             # edges in the adjacency list
@@ -224,7 +224,7 @@ class JobTest(ToilTest):
             except JobGraphDeadlockException:
                 pass  # This is the expected behaviour
 
-            def checkChildEdgeCycleDetection(fNode, tNode):                
+            def checkChildEdgeCycleDetection(fNode, tNode):
                 childEdges.add((fNode, tNode))  # Create a cycle
                 adjacencyList[fNode].add(tNode)
                 self.assertTrue(not self.isAcyclic(adjacencyList))
@@ -240,7 +240,7 @@ class JobTest(ToilTest):
                 # Check is now acyclic again
                 self.makeJobGraph(nodeNumber, childEdges,
                                   followOnEdges, None, False).checkJobGraphAcylic()
-                                  
+
             def checkFollowOnEdgeCycleDetection(fNode, tNode):
                 followOnEdges.add((fNode, tNode))  # Create a cycle
                 try:
@@ -260,10 +260,10 @@ class JobTest(ToilTest):
             # Pick a random existing order relationship
             fNode, tNode = self.getRandomEdge(nodeNumber)
             while tNode not in self.reachable(fNode, adjacencyList):
-                fNode, tNode = self.getRandomEdge(nodeNumber)  
-            
-            # Try creating a cycle of child edges
-            checkChildEdgeCycleDetection(tNode, fNode)   
+                fNode, tNode = self.getRandomEdge(nodeNumber)
+
+                # Try creating a cycle of child edges
+            checkChildEdgeCycleDetection(tNode, fNode)
 
             # Try adding a self child edge
             node = random.choice(range(nodeNumber))
@@ -278,7 +278,7 @@ class JobTest(ToilTest):
             # Try adding a follow on edge between two nodes with shared descendants
             fNode, tNode = self.getRandomEdge(nodeNumber)
             if (len(self.reachable(tNode, adjacencyList)
-                        .intersection(self.reachable(fNode, adjacencyList))) > 0
+                            .intersection(self.reachable(fNode, adjacencyList))) > 0
                 and (fNode, tNode) not in childEdges and (fNode, tNode) not in followOnEdges):
                 checkFollowOnEdgeCycleDetection(fNode, tNode)
 
@@ -427,7 +427,7 @@ class JobTest(ToilTest):
                 numberOfFailedJobs = 0
             except FailedJobsException as e:
                 numberOfFailedJobs = e.numberOfFailedJobs
-            
+
             # Restart until successful or failed
             totalTrys = 1
             options.restart = True
@@ -438,10 +438,10 @@ class JobTest(ToilTest):
                     numberOfFailedJobs = 0
                 except FailedJobsException as e:
                     numberOfFailedJobs = e.numberOfFailedJobs
-                    if totalTrys > 32: #p(fail after this many restarts) ~= 0.5**32
-                        self.fail() #Exceeded a reasonable number of restarts    
+                    if totalTrys > 32:  # p(fail after this many restarts) ~= 0.5**32
+                        self.fail()  # Exceeded a reasonable number of restarts
                     totalTrys += 1
-            
+
             # For each job check it created a valid output file and add the ordering
             # relationships contained within the output file to the ordering relationship,
             # so we can check they are compatible with the relationships defined by the job DAG.
@@ -464,7 +464,7 @@ class JobTest(ToilTest):
     def getRandomEdge(nodeNumber):
         assert nodeNumber > 1
         fNode = random.choice(range(nodeNumber - 1))
-        return fNode, random.choice(range(fNode+1, nodeNumber))
+        return fNode, random.choice(range(fNode + 1, nodeNumber))
 
     @staticmethod
     def makeRandomDAG(nodeNumber):
@@ -523,7 +523,7 @@ class JobTest(ToilTest):
                 # Let node2 be a child of node or a successor of a child of node.
                 # For all node2 the following adds an edge to the augmented 
                 # adjacency list from node2 to each followOn of node
-                
+
                 visited = set()
 
                 def f(node2):
@@ -578,19 +578,19 @@ class JobTest(ToilTest):
         def makeJob(string):
             promises = []
             job = Job.wrapFn(fn2Test, promises, string,
-                             None if outPath is None else os.path.join(outPath, string)) 
+                             None if outPath is None else os.path.join(outPath, string))
             jobsToPromisesMap[job] = promises
             return job
 
         # Make the jobs
         jobs = [makeJob(str(i)) for i in range(nodeNumber)]
-        
+
         # Make the edges
         for fNode, tNode in childEdges:
             jobs[fNode].addChild(jobs[tNode])
         for fNode, tNode in followOnEdges:
             jobs[fNode].addFollowOn(jobs[tNode])
-            
+
         # Map of jobs to return values
         jobsToRvs = dict([(job, job.addService(TrivialService(job.rv())) if addServices else job.rv()) for job in jobs])
 
@@ -633,8 +633,10 @@ class JobTest(ToilTest):
                 return False
         return True
 
+
 def simpleJobFn(job, value):
     job.fileStore.logToMaster(value)
+
 
 def fn1Test(string, outputFile):
     """

--- a/src/toil/test/src/miscTests.py
+++ b/src/toil/test/src/miscTests.py
@@ -25,11 +25,13 @@ import tempfile
 # Python 3 compatibility imports
 from six.moves import xrange
 
+
 class MiscTests(ToilTest):
     """
     This class contains miscellaneous tests that don't have enough content to be their own test
     file, and that don't logically fit in with any of the other test suites.
     """
+
     def setUp(self):
         super(MiscTests, self).setUp()
         self.testDir = self._createTempDir()
@@ -60,14 +62,14 @@ class MiscTests(ToilTest):
         # A dict of {FILENAME: FILESIZE} for all files used in the test
         files = {}
         # Create a random directory structure
-        for i in range(0,10):
+        for i in range(0, 10):
             directories.append(tempfile.mkdtemp(dir=random.choice(directories), prefix='test'))
         # Create 50 random file entries in different locations in the directories. 75% of the time
         # these are fresh files of sixe [1, 10] MB and 25% of the time they are hard links to old
         # files.
         while len(files) <= 50:
             fileName = os.path.join(random.choice(directories), self._getRandomName())
-            if random.randint(0,100) < 75:
+            if random.randint(0, 100) < 75:
                 # Create a fresh file in the range of 1-10 MB
                 fileSize = int(round(random.random(), 2) * 10 * 1024 * 1024)
                 with open(fileName, 'w') as fileHandle:
@@ -88,4 +90,3 @@ class MiscTests(ToilTest):
     @staticmethod
     def _getRandomName():
         return uuid4().hex
-

--- a/src/toil/test/src/promisedRequirementTest.py
+++ b/src/toil/test/src/promisedRequirementTest.py
@@ -101,7 +101,6 @@ class hidden(object):
             assert (minValue, maxValue) == (0, 0)
             return counterPath
 
-
         def testJobConcurrency(self):
             pass
 
@@ -237,4 +236,3 @@ class MesosPromisedRequirementsTest(hidden.AbstractPromisedRequirementsTest, Mes
 
     def tearDown(self):
         self._stopMesos()
-

--- a/src/toil/test/src/regularLogTest.py
+++ b/src/toil/test/src/regularLogTest.py
@@ -22,7 +22,6 @@ from toil.test.mesos import helloWorld
 
 
 class RegularLogTest(ToilTest):
-
     def setUp(self):
         super(RegularLogTest, self).setUp()
         self.tempDir = self._createTempDir(purpose='tempDir')
@@ -44,7 +43,6 @@ class RegularLogTest(ToilTest):
                 else:
                     mime = mimetypes.guess_type(log)
                     self.assertEqual(mime[1], encoding)
-
 
     @slow
     def testLogToMaster(self):
@@ -73,7 +71,7 @@ class RegularLogTest(ToilTest):
                                               '--clean=always',
                                               '--logLevel=debug',
                                               '--writeLogsGzip=%s' % self.tempDir],
-                                              stderr=subprocess.STDOUT)
+                                             stderr=subprocess.STDOUT)
         self._assertFileTypeExists(self.tempDir, '.log.gz', 'gzip')
 
     @slow

--- a/src/toil/test/src/restartDAGTest.py
+++ b/src/toil/test/src/restartDAGTest.py
@@ -26,7 +26,6 @@ import os
 import shutil
 import signal
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -35,6 +34,7 @@ class RestartDAGTest(ToilTest):
     Tests that restarted job DAGs don't run children of jobs that failed in the first run till the
     parent completes successfully in the restart.
     """
+
     def setUp(self):
         super(RestartDAGTest, self).setUp()
         self.tempDir = self._createTempDir(purpose='tempDir')
@@ -130,6 +130,7 @@ class RestartDAGTest(ToilTest):
             self.fail('Test failed for (%s) reasons:\n\t%s' % (len(failReasons),
                                                                '\n\t'.join(failReasons)))
 
+
 def passingFn(job, fileName=None):
     """
     This function is guaranteed to pass as it does nothing out of the ordinary.  If fileName is
@@ -140,6 +141,7 @@ def passingFn(job, fileName=None):
     if fileName is not None:
         # Emulates system touch.
         open(fileName, 'w').close()
+
 
 def failingFn(job, failType, fileName):
     """

--- a/src/toil/test/src/resumabilityTest.py
+++ b/src/toil/test/src/resumabilityTest.py
@@ -24,11 +24,13 @@ from toil.test import ToilTest, slow
 from toil.jobStores.abstractJobStore import NoSuchFileException
 from toil.leader import FailedJobsException
 
+
 @slow
 class ResumabilityTest(ToilTest):
     """
     https://github.com/BD2KGenomics/toil/issues/808
     """
+
     def test(self):
         """
         Tests that a toil workflow that fails once can be resumed without a NoSuchJobException.
@@ -56,6 +58,7 @@ class ResumabilityTest(ToilTest):
             # store ID: n/t/jobwbijqL failed with exit value 1"
             self.assertTrue("failed with exit value" not in logString)
 
+
 def parent(job):
     """
     Set up a bunch of dummy child jobs, and a bad job that needs to be
@@ -65,11 +68,13 @@ def parent(job):
         job.addChildJobFn(goodChild)
     job.addFollowOnJobFn(badChild)
 
+
 def goodChild(job):
     """
     Does nothing.
     """
     return
+
 
 def badChild(job):
     """

--- a/src/toil/test/src/retainTempDirTest.py
+++ b/src/toil/test/src/retainTempDirTest.py
@@ -18,10 +18,12 @@ from toil.job import Job
 from toil.leader import FailedJobsException
 from toil.test import ToilTest
 
+
 class CleanWorkDirTest(ToilTest):
     """
     Tests testing :class:toil.fileStore.FileStore
     """
+
     def setUp(self):
         super(CleanWorkDirTest, self).setUp()
         self.testDir = self._createTempDir()
@@ -88,9 +90,11 @@ class CleanWorkDirTest(ToilTest):
         else:
             self.fail("Toil run succeeded unexpectedly")
 
+
 def tempFileTestJob(job):
     with open(job.fileStore.getLocalTempFile(), "w") as f:
         f.write("test file retention")
+
 
 def tempFileTestErrorJob(job):
     with open(job.fileStore.getLocalTempFile(), "w") as f:

--- a/src/toil/test/src/toilContextManagerTest.py
+++ b/src/toil/test/src/toilContextManagerTest.py
@@ -60,6 +60,7 @@ class ToilContextManagerTest(ToilTest):
             # The file should have all our content
             self.assertEquals(f.read(), "Hello, World!")
 
+
 class HelloWorld(Job):
     def __init__(self):
         Job.__init__(self, memory=100000, cores=2, disk='1M')

--- a/src/toil/toilState.py
+++ b/src/toil/toilState.py
@@ -17,13 +17,15 @@ from __future__ import absolute_import
 from builtins import object
 import logging
 
-logger = logging.getLogger( __name__ )
+logger = logging.getLogger(__name__)
 
-class ToilState( object ):
+
+class ToilState(object):
     """
     Represents a snapshot of the jobs in the jobStore. Used by the leader to manage the batch.
     """
-    def __init__( self, jobStore, rootJob, jobCache=None):
+
+    def __init__(self, jobStore, rootJob, jobCache=None):
         """
         Loads the state from the jobStore, using the rootJob 
         as the source of the job graph.
@@ -35,39 +37,39 @@ class ToilState( object ):
         :param toil.jobWrapper.JobGraph rootJob
         """
         # This is a hash of jobs, referenced by jobStoreID, to their predecessor jobs.
-        self.successorJobStoreIDToPredecessorJobs = { }
-        
+        self.successorJobStoreIDToPredecessorJobs = {}
+
         # Hash of jobStoreIDs to counts of numbers of successors issued.
         # There are no entries for jobs
         # without successors in this map.
-        self.successorCounts = { }
+        self.successorCounts = {}
 
         # This is a hash of service jobs, referenced by jobStoreID, to their predecessor job
-        self.serviceJobStoreIDToPredecessorJob = { }
+        self.serviceJobStoreIDToPredecessorJob = {}
 
         # Hash of jobStoreIDs to maps of services issued for the job
         # Each for job, the map is a dictionary of service jobStoreIDs
         # to the flags used to communicate the with service
-        self.servicesIssued = { }
-        
+        self.servicesIssued = {}
+
         # Jobs that are ready to be processed
-        self.updatedJobs = set( )
-        
+        self.updatedJobs = set()
+
         # The set of totally failed jobs - this needs to be filtered at the
         # end to remove jobs that were removed by checkpoints
         self.totalFailedJobs = set()
-        
+
         # Jobs (as jobStoreIDs) with successors that have totally failed
         self.hasFailedSuccessors = set()
-        
+
         # The set of successors of failed jobs as a set of jobStoreIds
         self.failedSuccessors = set()
-        
+
         # Set of jobs that have multiple predecessors that have one or more predecessors
         # finished, but not all of them. This acts as a cache for these jobs.
         # Stored as hash from jobStoreIDs to job graphs
         self.jobsToBeScheduledWithMultiplePredecessors = {}
-        
+
         ##Algorithm to build this information
         logger.info("(Re)building internal scheduler state")
         self._buildToilState(rootJob, jobStore, jobCache)
@@ -106,70 +108,68 @@ class ToilState( object ):
             if jobGraph.checkpoint is not None:
                 jobGraph.command = jobGraph.checkpoint
 
-        else: # There exist successors
-            logger.debug("Adding job: %s to the state with %s successors" % (jobGraph.jobStoreID, len(jobGraph.stack[-1])))
-            
+        else:  # There exist successors
+            logger.debug(
+                "Adding job: %s to the state with %s successors" % (jobGraph.jobStoreID, len(jobGraph.stack[-1])))
+
             # Record the number of successors
             self.successorCounts[jobGraph.jobStoreID] = len(jobGraph.stack[-1])
-            
+
             def processSuccessorWithMultiplePredecessors(successorJobGraph):
                 # If jobGraph is not reported as complete by the successor
                 if jobGraph.jobStoreID not in successorJobGraph.predecessorsFinished:
-                    
                     # Update the sucessor's status to mark the predecessor complete
                     successorJobGraph.predecessorsFinished.add(jobGraph.jobStoreID)
-            
+
                 # If the successor has no predecessors to finish
                 assert len(successorJobGraph.predecessorsFinished) <= successorJobGraph.predecessorNumber
                 if len(successorJobGraph.predecessorsFinished) == successorJobGraph.predecessorNumber:
-                    
                     # It is ready to be run, so remove it from the cache
                     self.jobsToBeScheduledWithMultiplePredecessors.pop(successorJobStoreID)
-                    
+
                     # Recursively consider the successor
                     self._buildToilState(successorJobGraph, jobStore, jobCache=jobCache)
-            
+
             # For each successor
             for successorJobNode in jobGraph.stack[-1]:
                 successorJobStoreID = successorJobNode.jobStoreID
-                
+
                 # If the successor jobGraph does not yet point back at a
                 # predecessor we have not yet considered it
                 if successorJobStoreID not in self.successorJobStoreIDToPredecessorJobs:
 
                     # Add the job as a predecessor
                     self.successorJobStoreIDToPredecessorJobs[successorJobStoreID] = [jobGraph]
-                    
+
                     # If predecessor number > 1 then the successor has multiple predecessors
                     if successorJobNode.predecessorNumber > 1:
-                        
+
                         # We load the successor job
-                        successorJobGraph =  getJob(successorJobStoreID)
-                        
+                        successorJobGraph = getJob(successorJobStoreID)
+
                         # We put the successor job in the cache of successor jobs with multiple predecessors
                         assert successorJobStoreID not in self.jobsToBeScheduledWithMultiplePredecessors
                         self.jobsToBeScheduledWithMultiplePredecessors[successorJobStoreID] = successorJobGraph
-                        
+
                         # Process successor
                         processSuccessorWithMultiplePredecessors(successorJobGraph)
-                            
+
                     else:
                         # The successor has only the jobGraph as a predecessor so
                         # recursively consider the successor
                         self._buildToilState(getJob(successorJobStoreID), jobStore, jobCache=jobCache)
-                
+
                 else:
                     # We've already seen the successor
-                    
+
                     # Add the job as a predecessor
                     assert jobGraph not in self.successorJobStoreIDToPredecessorJobs[successorJobStoreID]
                     self.successorJobStoreIDToPredecessorJobs[successorJobStoreID].append(jobGraph)
-                    
+
                     # If the successor has multiple predecessors
                     if successorJobStoreID in self.jobsToBeScheduledWithMultiplePredecessors:
-                        
                         # Get the successor from cache
                         successorJobGraph = self.jobsToBeScheduledWithMultiplePredecessors[successorJobStoreID]
-                        
+
                         # Process successor
                         processSuccessorWithMultiplePredecessors(successorJobGraph)

--- a/src/toil/utils/toilClean.py
+++ b/src/toil/utils/toilClean.py
@@ -22,7 +22,8 @@ from toil.lib.bioio import parseBasicOptions
 from toil.common import Toil, jobStoreLocatorHelp, Config
 from toil.version import version
 
-logger = logging.getLogger( __name__ )
+logger = logging.getLogger(__name__)
+
 
 def main():
     parser = getBasicOptionParser()

--- a/src/toil/utils/toilLaunchCluster.py
+++ b/src/toil/utils/toilLaunchCluster.py
@@ -48,7 +48,7 @@ def main():
                              " }. ")
     parser.add_argument("--vpcSubnet",
                         help="VPC subnet ID to launch cluster in. Uses default subnet if not specified. "
-                        "This subnet needs to have auto assign IPs turned on.")
+                             "This subnet needs to have auto assign IPs turned on.")
     parser.add_argument("--nodeTypes", dest='nodeTypes', default=None, type=str,
                         help="Comma-separated list of node types to create while launching the leader. The "
                              "syntax for each node type depends on the "
@@ -84,7 +84,7 @@ def main():
             raise RuntimeError('The aws extra must be installed to use this provisioner')
         provisioner = AWSProvisioner()
 
-        #Parse leader node type and spot bid
+        # Parse leader node type and spot bid
         parsedBid = config.leaderNodeType.split(':', 1)
         if len(config.leaderNodeType) != len(parsedBid[0]):
             leaderSpotBid = float(parsedBid[1])
@@ -100,7 +100,7 @@ def main():
             for nodeTypeStr, num in zip(nodeTypesList, numWorkersList):
                 parsedBid = nodeTypeStr.split(':', 1)
                 if len(nodeTypeStr) != len(parsedBid[0]):
-                    #Is a preemptable node
+                    # Is a preemptable node
 
                     preemptableNodeTypes.append(parsedBid[0])
                     spotBids.append(float(parsedBid[1]))
@@ -116,7 +116,7 @@ def main():
                               nodeTypes=nodeTypes,
                               preemptableNodeTypes=preemptableNodeTypes,
                               numWorkers=numNodes,
-                              numPreemptableWorkers = numPreemptableNodes,
+                              numPreemptableWorkers=numPreemptableNodes,
                               keyName=config.keyPairName,
                               clusterName=config.clusterName,
                               spotBids=spotBids,

--- a/src/toil/utils/toilStats.py
+++ b/src/toil/utils/toilStats.py
@@ -31,13 +31,14 @@ from toil.common import Toil, jobStoreLocatorHelp, Config
 from toil.version import version
 from bd2k.util.expando import Expando
 
-logger = logging.getLogger( __name__ )
+logger = logging.getLogger(__name__)
 
 
 class ColumnWidths(object):
     """
     Convenience object that stores the width of columns for printing. Helps make things pretty.
     """
+
     def __init__(self):
         self.categories = ["time", "clock", "wait", "memory"]
         self.fields_count = ["count", "min", "med", "ave", "max", "total"]
@@ -46,48 +47,54 @@ class ColumnWidths(object):
         for category in self.categories:
             for field in self.fields_count:
                 self.setWidth(category, field, 8)
+
     def title(self, category):
         """ Return the total printed length of this category item.
         """
         return sum(
             [self.getWidth(category, x) for x in self.fields])
+
     def getWidth(self, category, field):
         category = category.lower()
         return self.data["%s_%s" % (category, field)]
+
     def setWidth(self, category, field, width):
         category = category.lower()
         self.data["%s_%s" % (category, field)] = width
+
     def report(self):
         for c in self.categories:
             for f in self.fields:
                 print('%s %s %d' % (c, f, self.getWidth(c, f)))
+
 
 def initializeOptions(parser):
     parser.add_argument("jobStore", type=str,
                         help="The location of the job store used by the workflow for which "
                              "statistics should be reported. " + jobStoreLocatorHelp)
     parser.add_argument("--outputFile", dest="outputFile", default=None,
-                      help="File in which to write results")
+                        help="File in which to write results")
     parser.add_argument("--raw", action="store_true", default=False,
-                      help="output the raw json data.")
+                        help="output the raw json data.")
     parser.add_argument("--pretty", "--human", action="store_true", default=False,
-                      help=("if not raw, prettify the numbers to be "
-                            "human readable."))
+                        help=("if not raw, prettify the numbers to be "
+                              "human readable."))
     parser.add_argument("--categories",
-                      help=("comma separated list from [time, clock, wait, "
-                            "memory]"))
+                        help=("comma separated list from [time, clock, wait, "
+                              "memory]"))
     parser.add_argument("--sortCategory", default="time",
-                      help=("how to sort Job list. may be from [alpha, "
-                            "time, clock, wait, memory, count]. "
-                            "default=%(default)s"))
+                        help=("how to sort Job list. may be from [alpha, "
+                              "time, clock, wait, memory, count]. "
+                              "default=%(default)s"))
     parser.add_argument("--sortField", default="med",
-                      help=("how to sort Job list. may be from [min, "
-                            "med, ave, max, total]. "
-                            "default=%(default)s"))
+                        help=("how to sort Job list. may be from [min, "
+                              "med, ave, max, total]. "
+                              "default=%(default)s"))
     parser.add_argument("--sortReverse", "--reverseSort", default=False,
-                      action="store_true",
-                      help="reverse sort order.")
+                        action="store_true",
+                        help="reverse sort order.")
     parser.add_argument("--version", action='version', version=version)
+
 
 def checkOptions(options, parser):
     """ Check options, throw parser.error() if something goes wrong
@@ -108,7 +115,7 @@ def checkOptions(options, parser):
     extraSort = ["count", "alpha"]
     if options.sortCategory is not None:
         if (options.sortCategory not in defaultCategories and
-            options.sortCategory not in extraSort):
+                    options.sortCategory not in extraSort):
             parser.error("Unknown --sortCategory %s. Must be from %s"
                          % (options.sortCategory,
                             str(defaultCategories + extraSort)))
@@ -119,11 +126,13 @@ def checkOptions(options, parser):
                          % (options.sortField, str(sortFields)))
     logger.info("Checked arguments")
 
+
 def printJson(elem):
     """ Return a JSON formatted string
     """
-    prettyString = json.dumps(elem, indent=4, separators=(',',': '))
+    prettyString = json.dumps(elem, indent=4, separators=(',', ': '))
     return prettyString
+
 
 def padStr(s, field=None):
     """ Pad the begining of a string with spaces, if necessary.
@@ -131,10 +140,11 @@ def padStr(s, field=None):
     if field is None:
         return s
     else:
-      if len(s) >= field:
-          return s
-      else:
-          return " " * (field - len(s)) + s
+        if len(s) >= field:
+            return s
+        else:
+            return " " * (field - len(s)) + s
+
 
 def prettyMemory(k, field=None, isBytes=False):
     """ Given input k as kilobytes, return a nicely formatted string.
@@ -151,6 +161,7 @@ def prettyMemory(k, field=None, isBytes=False):
         return padStr("%.1fT" % (k / 1024.0 / 1024.0 / 1024.0), field)
     if k < (1024 * 1024 * 1024 * 1024 * 1024):
         return padStr("%.1fP" % (k / 1024.0 / 1024.0 / 1024.0 / 1024.0), field)
+
 
 def prettyTime(t, field=None):
     """ Given input t as seconds, return a nicely formatted string.
@@ -172,26 +183,27 @@ def prettyTime(t, field=None):
         d = floor(t / 24. / 60. / 60.)
         h = floor((t - (d * 24. * 60. * 60.)) / 60. / 60.)
         m = floor(old_div((t
-                   - (d * 24. * 60. * 60.)
-                   - (h * 60. * 60.)), 60.))
+                           - (d * 24. * 60. * 60.)
+                           - (h * 60. * 60.)), 60.))
         s = t % 60
         dPlural = pluralDict[d > 1]
         return padStr("%dday%s%dh%dm%ds" % (d, dPlural, h, m, s), field)
     w = floor(t / 7. / 24. / 60. / 60.)
     d = floor((t - (w * 7 * 24 * 60 * 60)) / 24. / 60. / 60.)
     h = floor((t
-                 - (w * 7. * 24. * 60. * 60.)
-                 - (d * 24. * 60. * 60.))
-                / 60. / 60.)
+               - (w * 7. * 24. * 60. * 60.)
+               - (d * 24. * 60. * 60.))
+              / 60. / 60.)
     m = floor(old_div((t
-                 - (w * 7. * 24. * 60. * 60.)
-                 - (d * 24. * 60. * 60.)
-                 - (h * 60. * 60.)), 60.))
+                       - (w * 7. * 24. * 60. * 60.)
+                       - (d * 24. * 60. * 60.)
+                       - (h * 60. * 60.)), 60.))
     s = t % 60
     wPlural = pluralDict[w > 1]
     dPlural = pluralDict[d > 1]
     return padStr("%dweek%s%dday%s%dh%dm%ds" % (w, wPlural, d,
                                                 dPlural, h, m, s), field)
+
 
 def reportTime(t, options, field=None):
     """ Given t seconds, report back the correct format as string.
@@ -203,6 +215,7 @@ def reportTime(t, options, field=None):
             return "%*.2f" % (field, t)
         else:
             return "%.2f" % t
+
 
 def reportMemory(k, options, field=None, isBytes=False):
     """ Given k kilobytes, report back the correct format as string.
@@ -217,6 +230,7 @@ def reportMemory(k, options, field=None, isBytes=False):
         else:
             return "%dK" % int(k)
 
+
 def reportNumber(n, options, field=None):
     """ Given n an integer, report back the correct format as string.
     """
@@ -224,6 +238,7 @@ def reportNumber(n, options, field=None):
         return "%*g" % (field, n)
     else:
         return "%g" % n
+
 
 def refineData(root, options):
     """ walk down from the root and gather up the important bits.
@@ -236,6 +251,7 @@ def refineData(root, options):
         jobTypes.append(jobTypesTree[childName])
     return root, worker, job, jobTypes
 
+
 def sprintTag(key, tag, options, columnWidths=None):
     """ Generate a pretty-print ready string from a JTTag().
     """
@@ -247,7 +263,7 @@ def sprintTag(key, tag, options, columnWidths=None):
     out_str = ""
     if key == "job":
         out_str += " %-12s | %7s%7s%7s%7s\n" % ("Worker Jobs", "min",
-                                           "med", "ave", "max")
+                                                "med", "ave", "max")
         worker_str = "%s| " % (" " * 14)
         for t in [tag.min_number_per_worker, tag.median_number_per_worker,
                   tag.average_number_per_worker, tag.max_number_per_worker]:
@@ -264,7 +280,7 @@ def sprintTag(key, tag, options, columnWidths=None):
             (tag.average_time, columnWidths.getWidth("time", "ave")),
             (tag.max_time, columnWidths.getWidth("time", "max")),
             (tag.total_time, columnWidths.getWidth("time", "total")),
-            ]:
+        ]:
             tag_str += reportTime(t, options, field=width)
     if "clock" in options.categories:
         header += "| %*s " % (columnWidths.title("clock"),
@@ -277,7 +293,7 @@ def sprintTag(key, tag, options, columnWidths=None):
             (tag.average_clock, columnWidths.getWidth("clock", "ave")),
             (tag.max_clock, columnWidths.getWidth("clock", "max")),
             (tag.total_clock, columnWidths.getWidth("clock", "total")),
-            ]:
+        ]:
             tag_str += reportTime(t, options, field=width)
     if "wait" in options.categories:
         header += "| %*s " % (columnWidths.title("wait"),
@@ -290,7 +306,7 @@ def sprintTag(key, tag, options, columnWidths=None):
             (tag.average_wait, columnWidths.getWidth("wait", "ave")),
             (tag.max_wait, columnWidths.getWidth("wait", "max")),
             (tag.total_wait, columnWidths.getWidth("wait", "total")),
-            ]:
+        ]:
             tag_str += reportTime(t, options, field=width)
     if "memory" in options.categories:
         header += "| %*s " % (columnWidths.title("memory"),
@@ -303,12 +319,13 @@ def sprintTag(key, tag, options, columnWidths=None):
             (tag.average_memory, columnWidths.getWidth("memory", "ave")),
             (tag.max_memory, columnWidths.getWidth("memory", "max")),
             (tag.total_memory, columnWidths.getWidth("memory", "total")),
-            ]:
+        ]:
             tag_str += reportMemory(t, options, field=width, isBytes=True)
     out_str += header + "\n"
     out_str += sub_header + "\n"
     out_str += tag_str + "\n"
     return out_str
+
 
 def decorateTitle(title, options):
     """ Add a marker to TITLE if the TITLE is sorted on.
@@ -317,6 +334,7 @@ def decorateTitle(title, options):
         return "%s*" % title
     else:
         return title
+
 
 def decorateSubHeader(title, columnWidths, options):
     """ Add a marker to the correct field if the TITLE is sorted on.
@@ -344,6 +362,7 @@ def decorateSubHeader(title, columnWidths, options):
         s += " "
         return s
 
+
 def get(tree, name):
     """ Return a float value attribute NAME from TREE.
     """
@@ -357,6 +376,7 @@ def get(tree, name):
         a = float("nan")
     return a
 
+
 def sortJobs(jobTypes, options):
     """ Return a jobTypes all sorted.
     """
@@ -364,13 +384,12 @@ def sortJobs(jobTypes, options):
                  "ave": "average",
                  "min": "min",
                  "total": "total",
-                 "max": "max",}
+                 "max": "max", }
     sortField = longforms[options.sortField]
     if (options.sortCategory == "time" or
-        options.sortCategory == "clock" or
-        options.sortCategory == "wait" or
-        options.sortCategory == "memory"
-        ):
+            options.sortCategory == "clock" or
+            options.sortCategory == "wait" or
+            options.sortCategory == "memory"):
         return sorted(
             jobTypes,
             key=lambda tag: getattr(tag, "%s_%s"
@@ -384,20 +403,21 @@ def sortJobs(jobTypes, options):
         return sorted(jobTypes, key=lambda tag: tag.total_number,
                       reverse=options.sortReverse)
 
+
 def reportPrettyData(root, worker, job, job_types, options):
     """ print the important bits out.
     """
     out_str = "Batch System: %s\n" % root.batch_system
     out_str += ("Default Cores: %s  Default Memory: %s\n"
                 "Max Cores: %s\n" % (
-        reportNumber(get(root, "default_cores"), options),
-        reportMemory(get(root, "default_memory"), options, isBytes=True),
-        reportNumber(get(root, "max_cores"), options),
-        ))
+                    reportNumber(get(root, "default_cores"), options),
+                    reportMemory(get(root, "default_memory"), options, isBytes=True),
+                    reportNumber(get(root, "max_cores"), options),
+                ))
     out_str += ("Total Clock: %s  Total Runtime: %s\n" % (
         reportTime(get(root, "total_clock"), options),
         reportTime(get(root, "total_run_time"), options),
-        ))
+    ))
     job_types = sortJobs(job_types, options)
     columnWidths = computeColumnWidths(job_types, worker, job, options)
     out_str += "Worker\n"
@@ -409,6 +429,7 @@ def reportPrettyData(root, worker, job, job_types, options):
         out_str += sprintTag(t.name, t, options, columnWidths=columnWidths)
     return out_str
 
+
 def computeColumnWidths(job_types, worker, job, options):
     """ Return a ColumnWidths() object with the correct max widths.
     """
@@ -419,6 +440,7 @@ def computeColumnWidths(job_types, worker, job, options):
     updateColumnWidths(job, cw, options)
     return cw
 
+
 def updateColumnWidths(tag, cw, options):
     """ Update the column width attributes for this tag's fields.
     """
@@ -426,7 +448,7 @@ def updateColumnWidths(tag, cw, options):
                  "ave": "average",
                  "min": "min",
                  "total": "total",
-                 "max": "max",}
+                 "max": "max", }
     for category in ["time", "clock", "wait", "memory"]:
         if category in options.categories:
             for field in ["min", "med", "ave", "max", "total"]:
@@ -441,12 +463,14 @@ def updateColumnWidths(tag, cw, options):
                     # this string is larger than max, width must be increased
                     cw.setWidth(category, field, len(s) + 1)
 
+
 def buildElement(element, items, itemName):
     """ Create an element for output.
     """
-    def assertNonnegative(i,name):
+
+    def assertNonnegative(i, name):
         if i < 0:
-            raise RuntimeError("Negative value %s reported for %s" %(i,name) )
+            raise RuntimeError("Negative value %s reported for %s" % (i, name))
         else:
             return float(i)
 
@@ -459,8 +483,8 @@ def buildElement(element, items, itemName):
         itemMemory.append(assertNonnegative(item["memory"], "memory"))
     assert len(itemClocks) == len(itemTimes) == len(itemMemory)
 
-    itemWaits=[]
-    for index in range(0,len(itemTimes)):
+    itemWaits = []
+    for index in range(0, len(itemTimes)):
         itemWaits.append(itemTimes[index] - itemClocks[index])
 
     itemWaits.sort()
@@ -474,31 +498,32 @@ def buildElement(element, items, itemName):
         itemWaits.append(0)
         itemMemory.append(0)
 
-    element[itemName]=Expando(
+    element[itemName] = Expando(
         total_number=float(len(items)),
         total_time=float(sum(itemTimes)),
-        median_time=float(itemTimes[old_div(len(itemTimes),2)]),
-        average_time=float(old_div(sum(itemTimes),len(itemTimes))),
+        median_time=float(itemTimes[old_div(len(itemTimes), 2)]),
+        average_time=float(old_div(sum(itemTimes), len(itemTimes))),
         min_time=float(min(itemTimes)),
         max_time=float(max(itemTimes)),
         total_clock=float(sum(itemClocks)),
-        median_clock=float(itemClocks[old_div(len(itemClocks),2)]),
-        average_clock=float(old_div(sum(itemClocks),len(itemClocks))),
+        median_clock=float(itemClocks[old_div(len(itemClocks), 2)]),
+        average_clock=float(old_div(sum(itemClocks), len(itemClocks))),
         min_clock=float(min(itemClocks)),
         max_clock=float(max(itemClocks)),
         total_wait=float(sum(itemWaits)),
-        median_wait=float(itemWaits[old_div(len(itemWaits),2)]),
-        average_wait=float(old_div(sum(itemWaits),len(itemWaits))),
+        median_wait=float(itemWaits[old_div(len(itemWaits), 2)]),
+        average_wait=float(old_div(sum(itemWaits), len(itemWaits))),
         min_wait=float(min(itemWaits)),
         max_wait=float(max(itemWaits)),
         total_memory=float(sum(itemMemory)),
-        median_memory=float(itemMemory[old_div(len(itemMemory),2)]),
-        average_memory=float(old_div(sum(itemMemory),len(itemMemory))),
+        median_memory=float(itemMemory[old_div(len(itemMemory), 2)]),
+        average_memory=float(old_div(sum(itemMemory), len(itemMemory))),
         min_memory=float(min(itemMemory)),
         max_memory=float(max(itemMemory)),
         name=itemName
     )
     return element[itemName]
+
 
 def createSummary(element, containingItems, containingItemName, getFn):
     itemCounts = [len(getFn(containingItem)) for
@@ -515,14 +540,15 @@ def createSummary(element, containingItems, containingItemName, getFn):
 def getStats(jobStore):
     """ Collect and return the stats and config data.
     """
-    def aggregateStats(fileHandle,aggregateObject):
+
+    def aggregateStats(fileHandle, aggregateObject):
         try:
             stats = json.load(fileHandle, object_hook=Expando)
             for key in list(stats.keys()):
                 if key in aggregateObject:
                     aggregateObject[key].append(stats[key])
                 else:
-                    aggregateObject[key]=[stats[key]]
+                    aggregateObject[key] = [stats[key]]
         except ValueError:
             logger.critical("File %s contains corrupted json. Skipping file." % fileHandle)
             pass  # The file is corrupted.
@@ -572,10 +598,11 @@ def processData(config, stats):
     jobTypesTag = Expando()
     collatedStatsTag.job_types = jobTypesTag
     for jobName in jobNames:
-        jobTypes = [ job for job in jobs if job.class_name == jobName ]
+        jobTypes = [job for job in jobs if job.class_name == jobName]
         buildElement(jobTypesTag, jobTypes, jobName)
     collatedStatsTag.name = "collatedStatsTag"
     return collatedStatsTag
+
 
 def reportData(tree, options):
     # Now dump it all out to file
@@ -590,6 +617,7 @@ def reportData(tree, options):
         fileHandle.close()
     # Now dump onto the screen
     print(out_str)
+
 
 def main():
     """ Reports stats on the workflow, use with --stats option to toil.

--- a/src/toil/utils/toilStatus.py
+++ b/src/toil/utils/toilStatus.py
@@ -31,50 +31,51 @@ from toil.leader import ToilState
 from toil.job import JobException
 from toil.version import version
 
-logger = logging.getLogger( __name__ )
+logger = logging.getLogger(__name__)
+
 
 def main():
     """Reports the state of the toil.
     """
-    
+
     ##########################################
-    #Construct the arguments.
+    # Construct the arguments.
     ##########################################  
-    
+
     parser = getBasicOptionParser()
-    
+
     parser.add_argument("jobStore", type=str,
                         help="The location of a job store that holds the information about the "
                              "workflow whose status is to be reported on." + jobStoreLocatorHelp)
-    
+
     parser.add_argument("--verbose", dest="verbose", action="store_true",
-                      help="Print loads of information, particularly all the log files of \
+                        help="Print loads of information, particularly all the log files of \
                       jobs that failed. default=%(default)s",
-                      default=False)
-    
+                        default=False)
+
     parser.add_argument("--failIfNotComplete", dest="failIfNotComplete", action="store_true",
-                      help="Return exit value of 1 if toil jobs not all completed. default=%(default)s",
-                      default=False)
+                        help="Return exit value of 1 if toil jobs not all completed. default=%(default)s",
+                        default=False)
     parser.add_argument("--version", action='version', version=version)
     options = parseBasicOptions(parser)
     logger.info("Parsed arguments")
-    
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(0)
-    
+
     ##########################################
-    #Do some checks.
+    # Do some checks.
     ##########################################
-    
+
     logger.info("Checking if we have files for Toil")
     assert options.jobStore is not None
     config = Config()
     config.setOptions(options)
     ##########################################
-    #Survey the status of the job and report.
+    # Survey the status of the job and report.
     ##########################################  
-    
+
     jobStore = Toil.resumeJobStore(config.jobStore)
     try:
         rootJob = jobStore.loadRootJob()
@@ -86,6 +87,7 @@ def main():
     def traverseGraph(jobGraph):
         foundJobStoreIDs = set()
         totalJobs = []
+
         def inner(jobGraph):
             if jobGraph.jobStoreID in foundJobStoreIDs:
                 return
@@ -104,6 +106,7 @@ def main():
                         assert serviceJobStoreID not in foundJobStoreIDs
                         foundJobStoreIDs.add(serviceJobStoreID)
                         totalJobs.append(jobStore.load(serviceJobStoreID))
+
         inner(jobGraph)
         return totalJobs
 
@@ -139,7 +142,7 @@ def main():
         logger.info('These %i jobs are currently active: %s',
                     len(currentlyRunnning), ' \n'.join(map(str, currentlyRunnning)))
 
-    if options.verbose: #Verbose currently means outputting the files that have failed.
+    if options.verbose:  # Verbose currently means outputting the files that have failed.
         if failedJobs:
             msg = "Outputting logs for the %i failed jobs" % (len(failedJobs))
             msg += ": %s" % ", ".join((str(failedJob) for failedJob in failedJobs))
@@ -154,8 +157,9 @@ def main():
             print('There are no failed jobs to report.', file=sys.stderr)
 
     if totalJobs and options.failIfNotComplete:
-        exit(1) # when the workflow is complete, all jobs will have been removed from job store
+        exit(1)  # when the workflow is complete, all jobs will have been removed from job store
+
 
 def _test():
-    import doctest      
+    import doctest
     return doctest.testmod()

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import, print_function
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import str
 from builtins import map
@@ -58,13 +59,13 @@ def nextOpenDescriptor():
 class AsyncJobStoreWrite(object):
     def __init__(self, jobStore):
         pass
-    
+
     def writeFile(self, filePath):
         pass
-    
+
     def writeFileStream(self):
         pass
-    
+
     def blockUntilSync(self):
         pass
 
@@ -75,15 +76,15 @@ def main(argv=None):
         argv = sys.argv
 
     ##########################################
-    #Import necessary modules 
+    # Import necessary modules
     ##########################################
-    
+
     # This is assuming that worker.py is at a path ending in "/toil/worker.py".
     sourcePath = os.path.dirname(os.path.dirname(__file__))
     if sourcePath not in sys.path:
         sys.path.append(sourcePath)
-    
-    #Now we can import all the necessary functions
+
+    # Now we can import all the necessary functions
     from toil.lib.bioio import setLogLevel
     from toil.lib.bioio import getTotalCpuTime
     from toil.lib.bioio import getTotalCpuTimeAndMemoryUsage
@@ -97,7 +98,7 @@ def main(argv=None):
         from bd2k.util.ec2.credentials import enable_metadata_credential_caching
         enable_metadata_credential_caching()
     ##########################################
-    #Input args
+    # Input args
     ##########################################
 
     listOfJobs = [argv[1]]
@@ -105,24 +106,25 @@ def main(argv=None):
     jobStoreID = argv[3]
 
     ##########################################
-    #Load the jobStore/config file
+    # Load the jobStore/config file
     ##########################################
-    
+
     jobStore = Toil.resumeJobStore(jobStoreLocator)
     config = jobStore.config
-    
+
     ##########################################
-    #Create the worker killer, if requested
+    # Create the worker killer, if requested
     ##########################################
 
     logFileByteReportLimit = config.maxLogFileSize
 
     if config.badWorker > 0 and random.random() < config.badWorker:
         def badWorker():
-            #This will randomly kill the worker process at a random time 
+            # This will randomly kill the worker process at a random time
             time.sleep(config.badWorkerFailInterval * random.random())
-            os.kill(os.getpid(), signal.SIGKILL) #signal.SIGINT)
-            #TODO: FIX OCCASIONAL DEADLOCK WITH SIGINT (tested on single machine)
+            os.kill(os.getpid(), signal.SIGKILL)  # signal.SIGINT)
+            # TODO: FIX OCCASIONAL DEADLOCK WITH SIGINT (tested on single machine)
+
         t = Thread(target=badWorker)
         # Ideally this would be a daemon thread but that causes an intermittent (but benign)
         # exception similar to the one described here:
@@ -135,10 +137,10 @@ def main(argv=None):
         t.start()
 
     ##########################################
-    #Load the environment for the jobGraph
+    # Load the environment for the jobGraph
     ##########################################
-    
-    #First load the environment for the jobGraph.
+
+    # First load the environment for the jobGraph.
     with jobStore.readSharedFileStream("environment.pickle") as fileHandle:
         environment = pickle.load(fileHandle)
     for i in environment:
@@ -155,27 +157,27 @@ def main(argv=None):
     toilWorkflowDir = Toil.getWorkflowDir(config.workflowID, config.workDir)
 
     ##########################################
-    #Setup the temporary directories.
+    # Setup the temporary directories.
     ##########################################
-        
+
     # Dir to put all this worker's temp files in.
     localWorkerTempDir = tempfile.mkdtemp(dir=toilWorkflowDir)
     os.chmod(localWorkerTempDir, 0o755)
 
     ##########################################
-    #Setup the logging
+    # Setup the logging
     ##########################################
 
-    #This is mildly tricky because we don't just want to
-    #redirect stdout and stderr for this Python process; we want to redirect it
-    #for this process and all children. Consequently, we can't just replace
-    #sys.stdout and sys.stderr; we need to mess with the underlying OS-level
-    #file descriptors. See <http://stackoverflow.com/a/11632982/402891>
-    
-    #When we start, standard input is file descriptor 0, standard output is
-    #file descriptor 1, and standard error is file descriptor 2.
+    # This is mildly tricky because we don't just want to
+    # redirect stdout and stderr for this Python process; we want to redirect it
+    # for this process and all children. Consequently, we can't just replace
+    # sys.stdout and sys.stderr; we need to mess with the underlying OS-level
+    # file descriptors. See <http://stackoverflow.com/a/11632982/402891>
 
-    #What file do we want to point FDs 1 and 2 to?
+    # When we start, standard input is file descriptor 0, standard output is
+    # file descriptor 1, and standard error is file descriptor 2.
+
+    # What file do we want to point FDs 1 and 2 to?
     tempWorkerLogPath = os.path.join(localWorkerTempDir, "worker_log.txt")
 
     if not config.debugWorker:
@@ -204,53 +206,53 @@ def main(argv=None):
 
     debugging = logging.getLogger().isEnabledFor(logging.DEBUG)
     ##########################################
-    #Worker log file trapped from here on in
+    # Worker log file trapped from here on in
     ##########################################
 
     workerFailed = False
     statsDict = MagicExpando()
     statsDict.jobs = []
     statsDict.workers.logsToMaster = []
-    blockFn = lambda : True
-    cleanCacheFn = lambda x : True
+    blockFn = lambda: True
+    cleanCacheFn = lambda x: True
     try:
 
-        #Put a message at the top of the log, just to make sure it's working.
+        # Put a message at the top of the log, just to make sure it's working.
         print("---TOIL WORKER OUTPUT LOG---")
         sys.stdout.flush()
-        
-        #Log the number of open file descriptors so we can tell if we're leaking
-        #them.
+
+        # Log the number of open file descriptors so we can tell if we're leaking
+        # them.
         logger.debug("Next available file descriptor: {}".format(
             nextOpenDescriptor()))
 
         logProcessContext(config)
 
         ##########################################
-        #Load the jobGraph
+        # Load the jobGraph
         ##########################################
-        
+
         jobGraph = jobStore.load(jobStoreID)
         listOfJobs[0] = str(jobGraph)
         logger.debug("Parsed jobGraph")
-        
+
         ##########################################
-        #Cleanup from any earlier invocation of the jobGraph
+        # Cleanup from any earlier invocation of the jobGraph
         ##########################################
-        
+
         if jobGraph.command == None:
             # Cleanup jobs already finished
-            f = lambda jobs : [x for x in [[y for y in x if jobStore.exists(y.jobStoreID)] for x in jobs] if len(x) > 0]
+            f = lambda jobs: [x for x in [[y for y in x if jobStore.exists(y.jobStoreID)] for x in jobs] if len(x) > 0]
             jobGraph.stack = f(jobGraph.stack)
             jobGraph.services = f(jobGraph.services)
             logger.debug("Cleaned up any references to completed successor jobs")
 
-        #This cleans the old log file which may 
-        #have been left if the job is being retried after a job failure.
+        # This cleans the old log file which may
+        # have been left if the job is being retried after a job failure.
         oldLogFile = jobGraph.logJobStoreFileID
         if oldLogFile != None:
             jobGraph.logJobStoreFileID = None
-            jobStore.update(jobGraph) #Update first, before deleting any files
+            jobStore.update(jobGraph)  # Update first, before deleting any files
             jobStore.deleteFile(oldLogFile)
 
         ##########################################
@@ -273,31 +275,32 @@ def main(argv=None):
             # Otherwise, the job and successors are done, and we can cleanup stuff we couldn't clean
             # because of the job being a checkpoint
             else:
-                logger.debug("The checkpoint jobs seems to have completed okay, removing any checkpoint files to delete.")
-                #Delete any remnant files
+                logger.debug(
+                    "The checkpoint jobs seems to have completed okay, removing any checkpoint files to delete.")
+                # Delete any remnant files
                 list(map(jobStore.deleteFile, list(filter(jobStore.fileExists, jobGraph.checkpointFilesToDelete))))
 
         ##########################################
-        #Setup the stats, if requested
+        # Setup the stats, if requested
         ##########################################
-        
+
         if config.stats:
             startTime = time.time()
             startClock = getTotalCpuTime()
 
-        #Make a temporary file directory for the jobGraph
-        #localTempDir = makePublicDir(os.path.join(localWorkerTempDir, "localTempDir"))
+        # Make a temporary file directory for the jobGraph
+        # localTempDir = makePublicDir(os.path.join(localWorkerTempDir, "localTempDir"))
 
         startTime = time.time()
         while True:
             ##########################################
-            #Run the jobGraph, if there is one
+            # Run the jobGraph, if there is one
             ##########################################
-            
+
             if jobGraph.command is not None:
-                assert jobGraph.command.startswith( "_toil " )
+                assert jobGraph.command.startswith("_toil ")
                 logger.debug("Got a command to run: %s" % jobGraph.command)
-                #Load the job
+                # Load the job
                 job = Job._loadJob(jobGraph.command, jobStore)
                 # If it is a checkpoint job, save the command
                 if job.checkpoint:
@@ -319,36 +322,36 @@ def main(argv=None):
                 statsDict.workers.logsToMaster += fileStore.loggingMessages
 
             else:
-                #The command may be none, in which case
-                #the jobGraph is either a shell ready to be deleted or has
-                #been scheduled after a failure to cleanup
+                # The command may be none, in which case
+                # the jobGraph is either a shell ready to be deleted or has
+                # been scheduled after a failure to cleanup
                 break
-            
+
             if FileStore._terminateEvent.isSet():
                 raise RuntimeError("The termination flag is set")
 
             ##########################################
-            #Establish if we can run another jobGraph within the worker
+            # Establish if we can run another jobGraph within the worker
             ##########################################
-            
-            #If no more jobs to run or services not finished, quit
+
+            # If no more jobs to run or services not finished, quit
             if len(jobGraph.stack) == 0 or len(jobGraph.services) > 0 or jobGraph.checkpoint != None:
                 logger.debug("Stopping running chain of jobs: length of stack: %s, services: %s, checkpoint: %s",
                              len(jobGraph.stack), len(jobGraph.services), jobGraph.checkpoint != None)
                 break
-            
-            #Get the next set of jobs to run
+
+            # Get the next set of jobs to run
             jobs = jobGraph.stack[-1]
             assert len(jobs) > 0
-            
-            #If there are 2 or more jobs to run in parallel we quit
+
+            # If there are 2 or more jobs to run in parallel we quit
             if len(jobs) >= 2:
                 logger.debug("No more jobs can run in series by this worker,"
-                            " it's got %i children", len(jobs)-1)
+                             " it's got %i children", len(jobs) - 1)
                 break
-            
-            #We check the requirements of the jobGraph to see if we can run it
-            #within the current worker
+
+            # We check the requirements of the jobGraph to see if we can run it
+            # within the current worker
             successorJobNode = jobs[0]
             if successorJobNode.memory > jobGraph.memory:
                 logger.debug("We need more memory for the next job, so finishing")
@@ -374,8 +377,8 @@ def main(argv=None):
 
             # Somewhat ugly, but check if job is a checkpoint job and quit if
             # so
-            if successorJobGraph.command.startswith( "_toil " ):
-                #Load the job
+            if successorJobGraph.command.startswith("_toil "):
+                # Load the job
                 successorJob = Job._loadJob(successorJobGraph.command, jobStore)
 
                 # Check it is not a checkpoint
@@ -384,21 +387,21 @@ def main(argv=None):
                     break
 
             ##########################################
-            #We have a single successor job that is not a checkpoint job.
-            #We transplant the successor jobGraph command and stack
-            #into the current jobGraph object so that it can be run
-            #as if it were a command that were part of the current jobGraph.
-            #We can then delete the successor jobGraph in the jobStore, as it is
-            #wholly incorporated into the current jobGraph.
+            # We have a single successor job that is not a checkpoint job.
+            # We transplant the successor jobGraph command and stack
+            # into the current jobGraph object so that it can be run
+            # as if it were a command that were part of the current jobGraph.
+            # We can then delete the successor jobGraph in the jobStore, as it is
+            # wholly incorporated into the current jobGraph.
             ##########################################
-            
-            #Clone the jobGraph and its stack
+
+            # Clone the jobGraph and its stack
             jobGraph = copy.deepcopy(jobGraph)
-            
-            #Remove the successor jobGraph
+
+            # Remove the successor jobGraph
             jobGraph.stack.pop()
 
-            #These should all match up
+            # These should all match up
             assert successorJobGraph.memory == successorJobNode.memory
             assert successorJobGraph.cores == successorJobNode.cores
             assert successorJobGraph.predecessorsFinished == set()
@@ -406,7 +409,7 @@ def main(argv=None):
             assert successorJobGraph.command is not None
             assert successorJobGraph.jobStoreID == successorJobNode.jobStoreID
 
-            #Transplant the command and stack to the current jobGraph
+            # Transplant the command and stack to the current jobGraph
             jobGraph.command = successorJobGraph.command
             jobGraph.stack += successorJobGraph.stack
             # include some attributes for better identification of chained jobs in
@@ -415,28 +418,28 @@ def main(argv=None):
             jobGraph.jobName = successorJobGraph.jobName
             assert jobGraph.memory >= successorJobGraph.memory
             assert jobGraph.cores >= successorJobGraph.cores
-            
-            #Build a fileStore to update the job
+
+            # Build a fileStore to update the job
             fileStore = FileStore.createFileStore(jobStore, jobGraph, localWorkerTempDir, blockFn,
                                                   caching=not config.disableCaching)
 
-            #Update blockFn
+            # Update blockFn
             blockFn = fileStore._blockFn
 
-            #Add successorJobGraph to those to be deleted
+            # Add successorJobGraph to those to be deleted
             fileStore.jobsToDelete.add(successorJobGraph.jobStoreID)
-            
-            #This will update the job once the previous job is done
-            fileStore._updateJobWhenDone()            
-            
-            #Clone the jobGraph and its stack again, so that updates to it do
-            #not interfere with this update
+
+            # This will update the job once the previous job is done
+            fileStore._updateJobWhenDone()
+
+            # Clone the jobGraph and its stack again, so that updates to it do
+            # not interfere with this update
             jobGraph = copy.deepcopy(jobGraph)
-            
+
             logger.debug("Starting the next job")
-        
+
         ##########################################
-        #Finish up the stats
+        # Finish up the stats
         ##########################################
         if config.stats:
             totalCPUTime, totalMemoryUsage = getTotalCpuTimeAndMemoryUsage()
@@ -446,34 +449,35 @@ def main(argv=None):
 
         # log the worker log path here so that if the file is truncated the path can still be found
         logger.info("Worker log can be found at %s. Set --cleanWorkDir to retain this log", localWorkerTempDir)
-        logger.info("Finished running the chain of jobs on this node, we ran for a total of %f seconds", time.time() - startTime)
-    
+        logger.info("Finished running the chain of jobs on this node, we ran for a total of %f seconds",
+                    time.time() - startTime)
+
     ##########################################
-    #Trapping where worker goes wrong
+    # Trapping where worker goes wrong
     ##########################################
-    except: #Case that something goes wrong in worker
+    except:  # Case that something goes wrong in worker
         traceback.print_exc()
         logger.error("Exiting the worker because of a failed job on host %s", socket.gethostname())
         FileStore._terminateEvent.set()
-    
+
     ##########################################
-    #Wait for the asynchronous chain of writes/updates to finish
+    # Wait for the asynchronous chain of writes/updates to finish
     ########################################## 
-       
-    blockFn() 
-    
+
+    blockFn()
+
     ##########################################
-    #All the asynchronous worker/update threads must be finished now, 
-    #so safe to test if they completed okay
+    # All the asynchronous worker/update threads must be finished now,
+    # so safe to test if they completed okay
     ########################################## 
-    
+
     if FileStore._terminateEvent.isSet():
         jobGraph = jobStore.load(jobStoreID)
         jobGraph.setupJobAfterFailure(config)
         workerFailed = True
 
     ##########################################
-    #Cleanup
+    # Cleanup
     ##########################################
 
     # Close the worker logging
@@ -502,13 +506,13 @@ def main(argv=None):
 
     # Now our file handles are in exactly the state they were in before.
 
-    #Copy back the log file to the global dir, if needed
+    # Copy back the log file to the global dir, if needed
     if workerFailed:
         jobGraph.logJobStoreFileID = jobStore.getEmptyFileStoreID(jobGraph.jobStoreID)
         jobGraph.chainedJobs = listOfJobs
         with jobStore.updateFileStream(jobGraph.logJobStoreFileID) as w:
             with open(tempWorkerLogPath, "r") as f:
-                if os.path.getsize(tempWorkerLogPath) > logFileByteReportLimit !=0:
+                if os.path.getsize(tempWorkerLogPath) > logFileByteReportLimit != 0:
                     if logFileByteReportLimit > 0:
                         f.seek(-logFileByteReportLimit, 2)  # seek to last tooBig bytes of file
                     elif logFileByteReportLimit < 0:
@@ -527,15 +531,16 @@ def main(argv=None):
         statsDict.logs.names = listOfJobs
         statsDict.logs.messages = logMessages
 
-    if (debugging or config.stats or statsDict.workers.logsToMaster) and not workerFailed:  # We have stats/logging to report back
+    if (
+                    debugging or config.stats or statsDict.workers.logsToMaster) and not workerFailed:  # We have stats/logging to report back
         jobStore.writeStatsAndLogging(json.dumps(statsDict))
 
-    #Remove the temp dir
+    # Remove the temp dir
     cleanUp = config.cleanWorkDir
     if cleanUp == 'always' or (cleanUp == 'onSuccess' and not workerFailed) or (cleanUp == 'onError' and workerFailed):
         shutil.rmtree(localWorkerTempDir)
-    
-    #This must happen after the log file is done with, else there is no place to put the log
+
+    # This must happen after the log file is done with, else there is no place to put the log
     if (not workerFailed) and jobGraph.command == None and len(jobGraph.stack) == 0 and len(jobGraph.services) == 0:
         # We can now safely get rid of the jobGraph
         jobStore.delete(jobGraph.jobStoreID)


### PR DESCRIPTION
The hardest part are the naming conventions. This commit improves the code style by reducing the flake8 failures (assuming 120 line length) from 2009 to 811.

```
➜  toil git:(some_pep8_style) ✗ flake8 --max-line-length=120 src/toil | wc -l
811
➜  toil git:(some_pep8_style) ✗ git checkout master
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
➜  toil git:(master) ✗ flake8 --max-line-length=120 src/toil | wc -l
2009
```